### PR TITLE
fix buffer overflow

### DIFF
--- a/threading/smartptrs.nim
+++ b/threading/smartptrs.nim
@@ -108,9 +108,9 @@ proc newSharedPtr*[T](t: typedesc[T]): SharedPtr[T] =
   ## Returns a shared pointer. It is not initialized,
   ## so reading from it before writing to it is undefined behaviour!
   when not supportsCopyMem(T):
-    result.val = cast[typeof(result.val)](allocShared0(sizeof(T)))
+    result.val = cast[typeof(result.val)](allocShared0(sizeof(result.val[])))
   else:
-    result.val = cast[typeof(result.val)](allocShared(sizeof(T)))
+    result.val = cast[typeof(result.val)](allocShared(sizeof(result.val[])))
   int(result.val.counter) = 0
 
 proc isNil*[T](p: SharedPtr[T]): bool {.inline.} =


### PR DESCRIPTION
one has to account for the counter as well, when allocating a sharedptr