### PR TITLE
`threading.nimble`: Fix Nim dependency

### DIFF
--- a/threading.nimble
+++ b/threading.nimble
@@ -7,4 +7,4 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 1.4"
+requires "nim >= 1.4.6"


### PR DESCRIPTION
`extract` for `Isolated` not found for stable nim<1.4.6

Fixes #15