### PR TITLE
Fix conditional signaling bug, fix overriding `=` hook

### DIFF
--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -280,8 +280,7 @@ proc recvUnbufferedMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: st
   assert chan.isEmptyUnbuf()
 
   release(chan.lock)
-  when blocking:
-    signal(chan.spaceAvailableCV)
+  signal(chan.spaceAvailableCV)
   result = true
 
 proc recvMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
@@ -320,8 +319,7 @@ proc recvMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool)
     chan.tail = 0
 
   release(chan.lock)
-  when blocking:
-    signal(chan.spaceAvailableCV)
+  signal(chan.spaceAvailableCV)
   result = true
 
 
@@ -340,7 +338,7 @@ proc `=destroy`*[T](c: var Chan[T]) =
     else:
       atomicDec(c.d.atomicCounter)
 
-proc `=`*[T](dest: var Chan[T], src: Chan[T]) =
+proc `=copy`*[T](dest: var Chan[T], src: Chan[T]) =
   ## Shares `Channel` by reference counting.
   if src.d != nil:
     atomicInc(src.d.atomicCounter)

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -211,8 +211,7 @@ proc sendUnbufferedMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: st
   chan.tail = 1
 
   release(chan.lock)
-  when blocking:
-    signal(chan.dataAvailableCV)
+  signal(chan.dataAvailableCV)
   result = true
 
 proc sendMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
@@ -251,8 +250,7 @@ proc sendMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool)
     chan.head = 0
 
   release(chan.lock)
-  when blocking:
-    signal(chan.dataAvailableCV)
+  signal(chan.dataAvailableCV)
   result = true
 
 proc recvUnbufferedMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =


### PR DESCRIPTION
1. Conditionally sending the signal doesn't take into consideration the situation where only one side of a sender/receiver uses the blocking call. In a mixed situation a blocking end can never get a signal from a non-blocking end. So we need to send signals regardless of how the proc was invoked.\
 **TODO**: we probably need a test covering this situation.

2. Fixes "Overriding `=` hook is deprecated; Override `=copy` hook instead".