### PR TITLE
channels: Fix `trySend` template

### DIFF
--- a/tests/tchannels_singlebuf.nim
+++ b/tests/tchannels_singlebuf.nim
@@ -1,0 +1,41 @@
+## Test for and edge case of a channel with a single-element buffer:
+## https://github.com/nim-lang/threading/pull/27#issue-1652851878
+## Also tests `trySend` and `tryRecv` templates.
+
+import threading/channels
+const Message = "Hello"
+
+block trySend_recv:
+  proc test(chan: ptr Chan[string]) {.thread.} =
+    var notSent = true
+    var msg = Message
+    while notSent:
+      notSent = not chan[].trySend(msg)
+
+  var chan = newChan[string](elements = 1)
+  var thread: Thread[ptr Chan[string]]
+  var dest: string
+
+  createThread(thread, test, chan.addr)
+  chan.recv(dest)
+  doAssert dest == Message
+
+  thread.joinThread()
+
+
+block send_tryRecv:
+  proc test(chan: ptr Chan[string]) {.thread.} =
+    var notReceived = true
+    var msg: string
+    while notReceived:
+      notReceived = not chan[].tryRecv(msg)
+    doAssert msg == Message
+
+  var chan = newChan[string](elements = 1)
+  var thread: Thread[ptr Chan[string]]
+  let src = Message
+
+  createThread(thread, test, chan.addr)
+  chan.send(src)
+
+  thread.joinThread()

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -355,7 +355,7 @@ proc channelReceive[T](chan: Chan[T], data: ptr T, size: int, blocking: static b
   ## (Remove the first item)
   recvMpmc(chan.d, data, size, blocking)
 
-proc trySend*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
+proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
   ## Sends item to the channel (non blocking).
   var data = src.extract
   result = channelSend(c, data, sizeof(data), false)


### PR DESCRIPTION
- `var` arg changed to `sink` (Fixes #30)
- Added tests for both `try...` templates and the edge case from PR #27