### PR TITLE
CI: Bump deprecated builder images for Ubuntu and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,10 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
           - target:
               os: macos
-            builder: macos-10.15
+            builder: macos-11
           - target:
               os: windows
             builder: windows-2019


### PR DESCRIPTION
Ubuntu: 18.04 -> 20.04
macOS: 10.15 -> 11

I also noticed CI only tests arc, should we perhaps test orc too?

