### PR TITLE
Channels: remove "unbuffered" variant, clean-up, more docs

### DIFF
--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -6,23 +6,31 @@
 #    See the file "copying.txt", included in this
 #    distribution, for details about the copyright.
 #
-
-# Based on https://github.com/mratsim/weave/blob/5696d94e6358711e840f8c0b7c684fcc5cbd4472/unused/channels/channels_legacy.nim
-# Those are translations of @aprell (Andreas Prell) original channels from C to Nim
-# (https://github.com/aprell/tasking-2.0/blob/master/src/channel_shm/channel.c)
-# And in turn they are an implementation of Michael & Scott lock-based queues
-# (note the paper has 2 channels: lock-free and lock-based) with additional caching:
-# Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue Algorithms
-# Maged M. Michael, Michael L. Scott, 1996
-# https://www.cs.rochester.edu/~scott/papers/1996_PODC_queues.pdf
+# This Channel implementation is a shared memory concurrent queue using
+# a circular buffer for data. Based on channels implementation[1]_ by
+# Mamy André-Ratsimbazafy (@mratsim), which is a C to Nim translation of the
+# original[2]_ by Andreas Prell (@aprell)
+#
+# .. [1] https://github.com/mratsim/weave/blob/5696d94e6358711e840f8c0b7c684fcc5cbd4472/unused/channels/channels_legacy.nim
+# .. [2] https://github.com/aprell/tasking-2.0/blob/master/src/channel_shm/channel.c
 
 ## This module only works with `--gc:arc` or `--gc:orc`.
 ##
 ## .. warning:: This module is experimental and its interface may change.
 ##
+## This module implements multi-producer multi-consumer channels - a concurrency
+## primitive with a high-level interface intended for communication and
+## synchronization between threads. It allows sending and receiving typed data,
+## enabling safe and efficient concurrency.
+##
+## The `Chan` type represents a generic channel object that internally manages
+## the underlying resources and synchronization. It has to be initialized using
+## the `newChan` proc. Sending and receiving operations are provided by the
+## blocking `send` and `recv` procs, and non-blocking `trySend` and `tryRecv`
+## procs.
+##
 ## The following is a simple example of two different ways to use channels:
 ## blocking and non-blocking.
-##
 
 runnableExamples("--threads:on --gc:orc"):
   import std/os
@@ -33,51 +41,56 @@ runnableExamples("--threads:on --gc:orc"):
   # Note that isolated data passed through channels is moved around.
   var chan = newChan[string]()
 
-  # This proc will be run in another thread using the threads module.
-  proc firstWorker() =
-    chan.send("Hello World!")
+  block example_blocking:
+    # This proc will be run in another thread.
+    proc basicWorker() =
+      chan.send("Hello World!")
 
-  # This is another proc to run in a background thread. This proc takes a while
-  # to send the message since it sleeps for 2 seconds (or 2000 milliseconds).
-  proc secondWorker() =
-    sleep(2000)
-    chan.send("Another message")
+    # Launch the worker.
+    var worker: Thread[void]
+    createThread(worker, basicWorker)
 
-  # Launch the worker.
-  var worker1: Thread[void]
-  createThread(worker1, firstWorker)
+    # Block until the message arrives, then print it out.
+    var dest = ""
+    dest = chan.recv()
+    assert dest == "Hello World!"
 
-  # Block until the message arrives, then print it out.
-  var dest = ""
-  chan.recv(dest)
-  assert dest == "Hello World!"
+    # Wait for the thread to exit before moving on to the next example.
+    worker.joinThread()
 
-  # Wait for the thread to exit before moving on to the next example.
-  worker1.joinThread()
+  block example_non_blocking:
+    # This is another proc to run in a background thread. This proc takes a while
+    # to send the message since it first sleeps for some time.
+    proc slowWorker(delay: Natural) =
+      # `delay` is a period in milliseconds
+      sleep(delay)
+      chan.send("Another message")
 
-  # Launch the other worker.
-  var worker2: Thread[void]
-  createThread(worker2, secondWorker)
-  # This time, use a non-blocking approach with tryRecv.
-  # Since the main thread is not blocked, it could be used to perform other
-  # useful work while it waits for data to arrive on the channel.
-  var messages: seq[string]
-  while true:
-    var msg = ""
-    if chan.tryRecv(msg):
-      messages.add msg # "Another message"
-      break
+    # Launch the worker with a delay set to 2 seconds (2000 ms).
+    var worker: Thread[Natural]
+    createThread(worker, slowWorker, 2000)
 
-    messages.add "Pretend I'm doing useful work..."
-    # For this example, sleep in order not to flood stdout with the above
-    # message.
-    sleep(400)
+    # This time, use a non-blocking approach with tryRecv.
+    # Since the main thread is not blocked, it could be used to perform other
+    # useful work while it waits for data to arrive on the channel.
+    var messages: seq[string]
+    while true:
+      var msg = ""
+      if chan.tryRecv(msg):
+        messages.add msg # "Another message"
+        break
+      messages.add "Pretend I'm doing useful work..."
+      # For this example, sleep in order not to flood the sequence with too many
+      # "pretend" messages.
+      sleep(400)
 
-  # Wait for the second thread to exit before cleaning up the channel.
-  worker2.joinThread()
+    # Wait for the second thread to exit before cleaning up the channel.
+    worker.joinThread()
 
-  assert messages[^1] == "Another message"
-  assert messages.len >= 2
+    # Thread exits right after receiving the message
+    assert messages[^1] == "Another message"
+    # At least one non-successful attempt to receive the message had to occur.
+    assert messages.len >= 2
 
 when not defined(gcArc) and not defined(gcOrc) and not defined(nimdoc):
   {.error: "This channel implementation requires --gc:arc or --gc:orc".}
@@ -85,7 +98,7 @@ when not defined(gcArc) and not defined(gcOrc) and not defined(nimdoc):
 import std/[locks, atomics, isolation]
 import system/ansi_c
 
-# Channel (Shared memory channels)
+# Channel
 # ------------------------------------------------------------------------------
 
 type
@@ -93,63 +106,26 @@ type
   ChannelObj = object
     lock: Lock
     spaceAvailableCV, dataAvailableCV: Cond
-    closed: Atomic[bool]
-    size: int
-    itemsize: int # up to itemsize bytes can be exchanged over this channel
-    head: int     # Write/enqueue/send index
-    tail: int     # Read/dequeue/receive index
+    slots: int    ## Number of item slots in the buffer
+    head: int     ## Write/enqueue/send index
+    tail: int     ## Read/dequeue/receive index
     buffer: ptr UncheckedArray[byte]
     atomicCounter: Atomic[int]
 
-  ChannelCache = ptr ChannelCacheObj
-  ChannelCacheObj = object
-    next: ChannelCache
-    chanSize: int
-    chanN: int
-    numCached: int
-
 # ------------------------------------------------------------------------------
 
-proc numItems(chan: ChannelRaw): int {.inline.} =
+func numItems(chan: ChannelRaw): int {.inline.} =
   result = chan.head - chan.tail
   if result < 0:
-    inc(result, 2 * chan.size)
+    inc(result, 2 * chan.slots)
 
-  assert result <= chan.size
+  assert result <= chan.slots
 
 template isFull(chan: ChannelRaw): bool =
-  abs(chan.head - chan.tail) == chan.size
+  abs(chan.head - chan.tail) == chan.slots
 
 template isEmpty(chan: ChannelRaw): bool =
   chan.head == chan.tail
-
-# Unbuffered / synchronous channels
-# ------------------------------------------------------------------------------
-
-template numItemsUnbuf(chan: ChannelRaw): int =
-  chan.tail
-
-template isFullUnbuf(chan: ChannelRaw): bool =
-  chan.tail == 1
-
-template isEmptyUnbuf(chan: ChannelRaw): bool =
-  chan.tail == 0
-
-# ChannelRaw kinds
-# ------------------------------------------------------------------------------
-
-proc isUnbuffered(chan: ChannelRaw): bool =
-  chan.size == 1
-
-# ChannelRaw status and properties
-# ------------------------------------------------------------------------------
-
-when false:
-  proc isClosed(chan: ChannelRaw): bool {.inline.} = load(chan.closed, moRelaxed)
-
-proc peek(chan: ChannelRaw): int {.inline.} =
-  (if chan.isUnbuffered: numItemsUnbuf(chan) else: numItems(chan))
-
 
 # Channels memory ops
 # ------------------------------------------------------------------------------
@@ -164,9 +140,7 @@ proc allocChannel(size, n: int): ChannelRaw =
   initCond(result.spaceAvailableCV)
   initCond(result.dataAvailableCV)
 
-  result.closed.store(false, moRelaxed) # We don't need atomic here, how to?
-  result.size = n
-  result.itemsize = size
+  result.slots = n
   result.head = 0
   result.tail = 0
   result.atomicCounter.store(0, moRelaxed)
@@ -188,38 +162,9 @@ proc freeChannel(chan: ChannelRaw) =
 # MPMC Channels (Multi-Producer Multi-Consumer)
 # ------------------------------------------------------------------------------
 
-proc sendUnbufferedMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
-  when not blocking:
-    if chan.isFullUnbuf(): return false
-
-  # for a buffer of size=1 only tail index is used
-  acquire(chan.lock)
-
-  # check for when another thread was faster to fill
-  when blocking:
-    while chan.isFullUnbuf():
-      wait(chan.spaceAvailableCV, chan.lock)
-  else:
-    if chan.isFullUnbuf():
-      release(chan.lock)
-      return false
-
-  assert chan.isEmptyUnbuf()
-  assert size <= chan.itemsize
-  copyMem(chan.buffer, data, size)
-
-  chan.tail = 1
-
-  release(chan.lock)
-  signal(chan.dataAvailableCV)
-  result = true
-
-proc sendMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
+proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
   assert not chan.isNil
   assert not data.isNil
-
-  if isUnbuffered(chan):
-    return sendUnbufferedMpmc(chan, data, size, blocking)
 
   when not blocking:
     if chan.isFull(): return false
@@ -236,57 +181,25 @@ proc sendMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool)
       return false
 
   assert not chan.isFull()
-  assert size <= chan.itemsize
 
-  let writeIdx = if chan.head < chan.size:
+  let writeIdx = if chan.head < chan.slots:
       chan.head
     else:
-      chan.head - chan.size
+      chan.head - chan.slots
 
-  copyMem(chan.buffer[writeIdx * chan.itemsize].addr, data, size)
+  copyMem(chan.buffer[writeIdx * size].addr, data, size)
 
   inc(chan.head)
-  if chan.head == 2 * chan.size:
+  if chan.head == 2 * chan.slots:
     chan.head = 0
 
-  release(chan.lock)
   signal(chan.dataAvailableCV)
-  result = true
-
-proc recvUnbufferedMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
-  when not blocking:
-    if chan.isEmptyUnbuf(): return false
-
-  # for a buffer of size=1 only tail index is used
-  acquire(chan.lock)
-
-  # check for when another thread was faster to empty
-  when blocking:
-    while chan.isEmptyUnbuf():
-      wait(chan.dataAvailableCV, chan.lock)
-  else:
-    if chan.isEmptyUnbuf():
-      release(chan.lock)
-      return false
-
-  assert chan.isFullUnbuf()
-  assert size <= chan.itemsize
-
-  copyMem(data, chan.buffer, size)
-
-  chan.tail = 0
-  assert chan.isEmptyUnbuf()
-
   release(chan.lock)
-  signal(chan.spaceAvailableCV)
   result = true
 
-proc recvMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
+proc channelReceive(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
   assert not chan.isNil
   assert not data.isNil
-
-  if isUnbuffered(chan):
-    return recvUnbufferedMpmc(chan, data, size, blocking)
 
   when not blocking:
     if chan.isEmpty(): return false
@@ -303,29 +216,27 @@ proc recvMpmc(chan: ChannelRaw, data: pointer, size: int, blocking: static bool)
       return false
 
   assert not chan.isEmpty()
-  assert size <= chan.itemsize
 
-  let readIdx = if chan.tail < chan.size:
+  let readIdx = if chan.tail < chan.slots:
       chan.tail
     else:
-      chan.tail - chan.size
+      chan.tail - chan.slots
 
-  copyMem(data, chan.buffer[readIdx * chan.itemsize].addr, size)
+  copyMem(data, chan.buffer[readIdx * size].addr, size)
 
   inc(chan.tail)
-  if chan.tail == 2 * chan.size:
+  if chan.tail == 2 * chan.slots:
     chan.tail = 0
 
-  release(chan.lock)
   signal(chan.spaceAvailableCV)
+  release(chan.lock)
   result = true
-
 
 # Public API
 # ------------------------------------------------------------------------------
 
 type
-  Chan*[T] = object ## Typed channels
+  Chan*[T] = object ## Typed channel
     d: ChannelRaw
 
 proc `=destroy`*[T](c: var Chan[T]) =
@@ -345,65 +256,52 @@ proc `=copy`*[T](dest: var Chan[T], src: Chan[T]) =
     `=destroy`(dest)
   dest.d = src.d
 
-proc channelSend[T](chan: Chan[T], data: T, size: int, blocking: static bool): bool {.inline.} =
-  ## Send item to the channel (FIFO queue)
-  ## (Insert at last)
-  sendMpmc(chan.d, data.unsafeAddr, size, blocking)
-
-proc channelReceive[T](chan: Chan[T], data: ptr T, size: int, blocking: static bool): bool {.inline.} =
-  ## Receive an item from the channel
-  ## (Remove the first item)
-  recvMpmc(chan.d, data, size, blocking)
-
 proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
-  ## Sends item to the channel (non blocking).
+  ## Sends item to the channel (non-blocking).
   var data = src.extract
-  result = channelSend(c, data, sizeof(data), false)
+  result = channelSend(c.d, data.unsafeAddr, sizeof(T), false)
   if result:
     wasMoved(data)
 
 template trySend*[T](c: Chan[T], src: T): bool =
-  ## Helper templates for `trySend`.
+  ## Helper template for `trySend`.
   trySend(c, isolate(src))
 
 proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
-  ## Receives item from the channel (non blocking).
-  channelReceive(c, dst.addr, sizeof(dst), false)
+  ## Receives item from the channel (non-blocking).
+  channelReceive(c.d, dst.addr, sizeof(T), false)
 
 proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
   ## Sends item to the channel (blocking).
   var data = src.extract
   when defined(gcOrc) and defined(nimSafeOrcSend):
     GC_runOrc()
-  discard channelSend(c, data, sizeof(data), true)
+  discard channelSend(c.d, data.unsafeAddr, sizeof(T), true)
   wasMoved(data)
 
 template send*[T](c: Chan[T]; src: T) =
-  ## Helper templates for `send`.
+  ## Helper template for `send`.
   send(c, isolate(src))
 
 proc recv*[T](c: Chan[T], dst: var T) {.inline.} =
   ## Receives item from the channel (blocking).
-  discard channelReceive(c, dst.addr, sizeof(dst), true)
+  discard channelReceive(c.d, dst.addr, sizeof(T), true)
 
 proc recv*[T](c: Chan[T]): T {.inline.} =
   ## Receives item from the channel (blocking).
-  discard channelReceive(c, result.addr, sizeof(result), true)
+  discard channelReceive(c.d, result.addr, sizeof(result), true)
 
 proc recvIso*[T](c: Chan[T]): Isolated[T] {.inline.} =
   var dst: T
-  discard channelReceive(c, dst.addr, sizeof(dst), true)
+  discard channelReceive(c.d, dst.addr, sizeof(T), true)
   result = isolate(dst)
 
-when false:
-  proc open*[T](c: Chan[T]) {.inline.} =
-    store(c.d.closed, false, moRelaxed)
-
-  proc close*[T](c: Chan[T]) {.inline.} =
-    store(c.d.closed, true, moRelaxed)
-
-proc peek*[T](c: Chan[T]): int {.inline.} = peek(c.d)
+func peek*[T](c: Chan[T]): int {.inline.} =
+  ## Returns an estimation of current number of items held by the channel.
+  numItems(c.d)
 
 proc newChan*[T](elements: Positive = 30): Chan[T] =
+  ## An initialization procedure, necessary for acquiring resources and
+  ## initializing internal state of the channel.
   assert elements >= 1, "Elements must be positive!"
   result = Chan[T](d: allocChannel(sizeof(T), elements))


### PR DESCRIPTION
- The so-called "unbuffered" version was actually just a special case for a channel with a buffer of length = 1. It still used the same raw object underneath and utilized only one index cursor for all operations. The only real difference was replacing the size calculations with basic comparisons to one and zero (full / empty), which are negligible and do not justify having duplicates of critical code and adding another if-branched function call to each send/receive operation. Real unbuffered version would provide a rendezvous synchronization for transferring data from source to destination without a buffer. 

- The signaling was moved inside the locks' critical sections ([reasoning](https://github.com/Araq/malebolgia/issues/4#issuecomment-1553661632)).

- The internal `itemSize` field was removed as each operation already has this information passed as an argument (from the typed front-end interface to procs operating on the raw object).

- The internal `size` field was renamed to `slots` to remove ambiguity: now it's clear it's a number of items, not a number of bytes.

- Remnants of the unused features of the original implementation were removed:
   * In case of the atomic `closed` field it was just an unused weight.
   * Corresponding procs (`open`, `close`, `isClosed`) were when-falsed.
   * `ChannelCache` was dead code.

- Removed hidden procs with a useless indirection from the "Public API" block.

- The mention of the [Michael-Scott paper](https://www.cs.rochester.edu/u/scott/papers/1996_PODC_queues.pdf) was removed, because this implementation has very little in common with its contents, besides being a concurrent queue and using locks. Things that really matter differ:

  | channels.nim   | 1996_PODC_queues fig.2 |
  |----------------|------------------------|
  | one lock       | two locks              |
  | bounded        | unbounded              |
  | ringbuffer     | linked list            |
  | [non-]blocking[^nb] | technically blocking[^b]   |

[^nb]: More complex combined logic, using conditional signaling.
[^b]: Blocking on acquiring the lock, but no waiting for resources due to being unbounded.