### PR TITLE
Set up documentation on GitHub Pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,28 @@
+---
+name: docs
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+env:
+  nim-src: src/${{ github.event.repository.name }}.nim
+  deploy-dir: .gh-pages
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: 'devel'
+      - run: nimble install -Y
+      - run: nimble doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
+      - name: "Copy to index.html"
+        run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html
+      - name: Deploy documents
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.deploy-dir }}

--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,2 @@
 # threading
-New atomics, thread primitives, channels and atomic refcounting for --gc:arc/orc.
+New atomics, thread primitives, channels and atomic refcounting for --gc:arc/orc. Documentation: https://nim-lang.github.io/threading.


### PR DESCRIPTION
This workflow is the same as for [bigints](https://github.com/nim-lang/bigints). When merging, you need to select the `gh-pages` branch for deployment (Settings -> Pages -> Branch).