### PR TITLE
Attach `error` pragma to `[]=` proc

### DIFF
--- a/threading/smartptrs.nim
+++ b/threading/smartptrs.nim
@@ -160,7 +160,7 @@ proc `[]`*[T](p: ConstPtr[T]): lent T {.inline.} =
   checkNotNil(p)
   SharedPtr[T](p).val.value
 
-proc `[]=`*[T](p: ConstPtr[T], v: T) = {.error: "`ConstPtr` cannot be assigned.".}
+proc `[]=`*[T](p: ConstPtr[T], v: T) {.error: "`ConstPtr` cannot be assigned.".}
 
 proc `$`*[T](p: ConstPtr[T]): string {.inline.} =
   $SharedPtr[T](p)


### PR DESCRIPTION
This makes the `error` pragma show up in the documentation and avoids a "template/generic instantiation" error message.