### PR TITLE
Improve `waitgroups`

### DIFF
--- a/tests/twaitgroups.nim
+++ b/tests/twaitgroups.nim
@@ -1,0 +1,42 @@
+import threading/waitgroups
+
+block basic:
+  var wg = createWaitGroup()
+  wg.enter(10)
+  for _ in 1..10:
+    wg.leave()
+  wg.wait()
+
+block multiple_threads:
+  var data: array[10, int]
+  var wg = createWaitGroup()
+
+  proc worker(i: int) =
+    data[i] = 42
+    wg.leave()
+
+  var threads: array[10, Thread[int]]
+  wg.enter(10)
+  for i in 0..<10:
+    createThread(threads[i], worker, i)
+
+  wg.wait()
+  for x in data:
+    doAssert x == 42
+
+  joinThreads(threads)
+
+block multiple_waits:
+  var wg = createWaitGroup()
+  wg.enter(1)
+
+  proc worker() =
+    wg.wait()
+
+  var threads: array[10, Thread[void]]
+  for i in 0..<10:
+    createThread(threads[i], worker)
+
+  wg.leave()
+
+  joinThreads(threads)

--- a/threading/waitgroups.nim
+++ b/threading/waitgroups.nim
@@ -52,11 +52,10 @@ proc createWaitGroup*(): WaitGroup =
   initCond(result.c)
   initLock(result.L)
 
-proc enter*(b: var WaitGroup; delta = 1) {.inline.} =
+proc enter*(b: var WaitGroup; delta: Natural = 1) {.inline.} =
   ## Tells the `WaitGroup` that one or more workers (the `delta` parameter says
   ## how many) "entered", which means to increase the counter that counts how
   ## many workers to wait for.
-  doAssert delta > 0
   acquire(b.L)
   inc b.runningTasks, delta
   release(b.L)

--- a/threading/waitgroups.nim
+++ b/threading/waitgroups.nim
@@ -8,11 +8,32 @@
 
 ## Wait groups for Nim.
 
+runnableExamples:
+
+  var data: array[10, int]
+  var wg = createWaitGroup()
+
+  proc worker(i: int) =
+    data[i] = 42
+    wg.leave()
+
+  var threads: array[10, Thread[int]]
+  wg.enter(10)
+  for i in 0..<10:
+    createThread(threads[i], worker, i)
+
+  wg.wait()
+  for x in data:
+    assert x == 42
+
+  joinThreads(threads)
+
+
 import std / [locks]
 
 type
   WaitGroup* = object
-    ## A WaitGroup is a synchronization object that can be used to `wait` until
+    ## A `WaitGroup` is a synchronization object that can be used to `wait` until
     ## all workers have completed.
     c: Cond
     L: Lock
@@ -32,8 +53,8 @@ proc createWaitGroup*(): WaitGroup =
   initLock(result.L)
 
 proc enter*(b: var WaitGroup; delta = 1) {.inline.} =
-  ## Tells the WaitGroup that one or more workers (the `delta` parameter says
-  ## how many) "entered" which means to increase the counter that counts how
+  ## Tells the `WaitGroup` that one or more workers (the `delta` parameter says
+  ## how many) "entered", which means to increase the counter that counts how
   ## many workers to wait for.
   doAssert delta > 0
   acquire(b.L)
@@ -41,7 +62,7 @@ proc enter*(b: var WaitGroup; delta = 1) {.inline.} =
   release(b.L)
 
 proc leave*(b: var WaitGroup) {.inline.} =
-  ## Tells the WaitGroup that one worker has finished its task.
+  ## Tells the `WaitGroup` that one worker has finished its task.
   acquire(b.L)
   if b.runningTasks > 0:
     dec b.runningTasks


### PR DESCRIPTION
* fix some bugs:
  - assert `delta >= 0` in `enter` by making the argument type `Natural` (Go also supports negative deltas, but those would require special handling)
  - `leave` does nothing if no tasks have entered (it could also throw an exception, like Go does)
  - only notify when `runningTasks` is 0 (not a bug fix, but an optimization)
  - use `broadcast` instead of `signal` in `leave` (this allows multiple threads to `wait`, there is a test for this)
* add tests
* improve documentation

---

What do you think about the behaviour of `enter` if `delta < 0` and `leave` if `runningTasks == 0`?