### PR TITLE
Bump nim dependency to 1.6.0, expand `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,2 +1,11 @@
 # threading
-New atomics, thread primitives, channels and atomic refcounting for --gc:arc/orc. Documentation: https://nim-lang.github.io/threading.
+
+New threading primitives for Nim's `arc`/`orc` memory management modes: atomics, channels, smart pointers and wait groups.
+
+## Documentation
+
+> These modules require `--mm:arc` or `--mm:orc`!
+
+Documentation: https://nim-lang.github.io/threading
+
+See [tests/](./tests/) for some usage examples.

--- a/threading.nimble
+++ b/threading.nimble
@@ -2,9 +2,9 @@
 
 version       = "0.1.0"
 author        = "Araq"
-description   = "New atomics, thread primitives, channels and atomic refcounting for --gc:arc/orc."
+description   = "New threading primitives for --mm:arc/orc: atomics, channels, smart pointers and wait groups."
 license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 1.4.6"
+requires "nim >= 1.6.0"

--- a/threading.nimble
+++ b/threading.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Araq"
 description   = "New threading primitives for --mm:arc/orc: atomics, channels, smart pointers and wait groups."
 license       = "MIT"


### PR DESCRIPTION
Bump nim dependency to 1.6.0

Expand `readme.md`: `gc` -> `mm`, mention `tests/` as examples, mention newly added wait groups.

Isn't it the time to bump the version? Changing the minor number seems suitable.