### PR TITLE
#52 Expand channel documentation

### DIFF
--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -31,7 +31,7 @@
 ## remove them.
 ## 
 ## See also:
-## * [std/isolate](https://nim-lang.org/docs/isolation.html)
+## * [std/isolation](https://nim-lang.org/docs/isolation.html)
 ##
 ## The following is a simple example of two different ways to use channels:
 ## blocking and non-blocking.


### PR DESCRIPTION
Closes #52 

A small PR based on what I learned about channels. Regard every change I made with suspicion, I am still starting out in learning about channels, multithreaded communication etc.

I very deliberately stole a lot of the descriptions from Nim's channels_builtin module ([example](https://nim-lang.org/docs/system.html#tryRecv%2CChannel%5BTMsg%5D) ) and adjusted them to keep descriptions somewhat consistent.

I also added an external hyperlink to `std/isolation` to the general module docs, because the imports don't show in them and neither does `Isolated` have any hyperlinks to its own type. This makes it unclear for users where to find the type if they have no context (I mean, I had none, I'm just diving into the multithreading space now) and therefore there should be a link somewhere.

I am also very uncertain about a sentence I used repeatedly here:
`## The memory `src` is moved, not copied.`

That is my current understanding of threading/channels, but I don't quite know that for sure, so if that needs correcting please say so.