### PR TITLE
Correct doc mistakes

### DIFF
--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -277,8 +277,9 @@ proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
   ## Instead returns after an attempt to send a message was made.
   ## 
   ## .. warning:: Blocking is still possible if another thread uses the blocking
-  ##    version of `send`/`recv` and waits for the data/space to appear in the
-  ##    channel, thus holding the internal lock to channel's buffer.
+  ##    version of the `send proc`_ / `recv proc`_ and waits for the 
+  ##    data/space to appear in the channel, thus holding the internal lock to 
+  ##    channel's buffer.
   ##
   ## Returns `false` if the message was not sent because the number of pending
   ## messages in the channel exceeded its capacity.
@@ -298,8 +299,8 @@ proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## Instead returns after an attempt to receive a message was made.
   ## 
   ## .. warning:: Blocking is still possible if another thread uses the blocking
-  ##    version of `send`/`recv` and waits for the data/space to appear in the
-  ##    channel, thus holding the internal lock to channel's buffer.
+  ##    version of the `send proc`_ / `recv proc`_ and waits for the data/space to 
+  ##    appear in the channel, thus holding the internal lock to channel's buffer.
   ## 
   ## Returns `false` and does not change `dist` if no message was received.
   channelReceive(c.d, dst.addr, sizeof(T), false)

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -270,7 +270,7 @@ proc `=copy`*[T](dest: var Chan[T], src: Chan[T]) =
   dest.d = src.d
 
 proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
-  ## Tries to send a message `src` to the channel `c`.
+  ## Tries to send the message `src` to the channel `c`.
   ##
   ## The memory of `src` is moved, not copied. 
   ## Doesn't block waiting for space in the channel to become available.
@@ -293,7 +293,7 @@ template trySend*[T](c: Chan[T], src: T): bool =
   trySend(c, isolate(src))
 
 proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
-  ## Tries to receive an message from the channel `c` and fill `dst` with its value.
+  ## Tries to receive a message from the channel `c` and fill `dst` with its value.
   ## 
   ## Doesn't block waiting for messages in the channel to become available.
   ## Instead returns after an attempt to receive a message was made.
@@ -306,7 +306,7 @@ proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   channelReceive(c.d, dst.addr, sizeof(T), false)
 
 proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
-  ## Sends message `src` to the channel `c`. 
+  ## Sends the message `src` to the channel `c`. 
   ## This blocks the sending thread until `src` was successfully sent.
   ## 
   ## The memory of `src` is moved, not copied. 


### PR DESCRIPTION
The doc comments implied that tryRecv and trySend do not block. That is incorrect.

They do not block *waiting for data*.
They *do* block trying to acquire the lock to the channel.

Also some adjustments for better uniformity in the docs:
- Messages renamed to items
- Some doc comments were made more similar to one another in text style

@ZoomRmc Tried to include the changes you suggested in #53 