### PR TITLE
Bugfix/#55 refactor to atomics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nimcache/
 nimblecache/
 htmldocs/
+tests/tsmartptrsleak
+tests/tchannels_simple

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,9 +1,9 @@
 --path:"../"
 --gc:arc
 --threads:on
---cc:clang
 --define:useMalloc
 @if not windows:
+  --cc:clang
   --debugger:native 
   --passc:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" 
   --passl:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,3 +1,7 @@
 --path:"../"
 --gc:arc
 --threads:on
+--cc:clang
+--debugger:native 
+--passc:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" 
+--passl:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -2,6 +2,7 @@
 --gc:arc
 --threads:on
 --cc:clang
+--define:useMalloc
 --debugger:native 
 --passc:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" 
 --passl:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -3,6 +3,8 @@
 --threads:on
 --cc:clang
 --define:useMalloc
---debugger:native 
---passc:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" 
---passl:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+@if not windows:
+  --debugger:native 
+  --passc:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" 
+  --passl:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+@end

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -2,9 +2,13 @@
 --gc:arc
 --threads:on
 --define:useMalloc
+--cc:clang
 @if not windows:
-  --cc:clang
   --debugger:native 
   --passc:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" 
   --passl:"-fsanitize=thread -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
+@end
+@if windows and i386:
+  --passc:"-m32"
+  --passl:"-m32"
 @end

--- a/threading/smartptrs.nim
+++ b/threading/smartptrs.nim
@@ -93,7 +93,7 @@ proc decr[T](p: SharedPtr[T]) {.inline.} =
   if p.val != nil:
     # this `fetchSub` returns current val then subs
     # so count == 0 means we're the last
-    if p.val.counter.fetchSub(1, Release) == 0:
+    if p.val.counter.fetchSub(1, AcqRel) == 0:
       `=destroy`(p.val.value)
       deallocShared(p.val)
 
@@ -119,7 +119,7 @@ proc newSharedPtr*[T](val: sink Isolated[T]): SharedPtr[T] {.nodestroy.} =
   ## Returns a shared pointer which shares
   ## ownership of the object by reference counting.
   result.val = cast[typeof(result.val)](allocShared(sizeof(result.val[])))
-  int(result.val.counter) = 0
+  result.val.counter.store(0)
   result.val.value = extract val
 
 template newSharedPtr*[T](val: T): SharedPtr[T] =


### PR DESCRIPTION
closes #55.

This is my first stab at refactoring Channels to use atomics instead of raw integers to get rid of data-races.

As for why, see commit message:

> Head and Tail on ChannelRaw get accessed in channelSend and channelReceive
before a lock acquisition happens in those procs.
That means that the output of the template they get used in (isEmpty/isFull) is dependent on a data-race.

> That is because as a thread that has the lock may modify those values while they are being
read by another thrread without the lock.
This is noticed by thread-sanitizer and should be eliminated for the following reasons:
> - Users should not catch "false positives" for thread sanitizier such as this, which they currently will
> - It is generally a good idea to have multi-threaded code such as this data-race free

> This refactor to atomics makes the entire thing atomic and thus impossible to have a
data-race with.

While I was at it I also refactored access to atomicCounter, mostly for consistency since with head/tail since I access those via getters/setters.

This is a draft since I'd like to present it for now and I would also like to add thread-sanitizer and address sanitizer checks to the general tests in the test-suite.
Meaning the test-suite should fail if either of those notice something wrong (in my opinion).
I'll try to do that once I figure out how, my head is mildly foggy from a cold right now and infrastructure config was always a tad harder for me.