### PR TITLE
Introduces using doAssert for tests consistently

### DIFF
--- a/tests/tatomics.nim
+++ b/tests/tatomics.nim
@@ -4,238 +4,238 @@ import std/bitops, threading/atomics
 block trivialLoad:
   var location: Atomic[int]
   location.store(1)
-  assert location.load == 1
+  doAssert location.load == 1
   location.store(2)
-  assert location.load(Relaxed) == 2
+  doAssert location.load(Relaxed) == 2
   location.store(3)
-  assert location.load(Acquire) == 3
+  doAssert location.load(Acquire) == 3
 
 block trivialStore:
   var location: Atomic[int]
   location.store(1)
-  assert location.load == 1
+  doAssert location.load == 1
   location.store(2, Relaxed)
-  assert location.load == 2
+  doAssert location.load == 2
   location.store(3, Release)
-  assert location.load == 3
+  doAssert location.load == 3
 
 block trivialExchange:
   var location: Atomic[int]
   location.store(1)
-  assert location.exchange(2) == 1
-  assert location.exchange(3, Relaxed) == 2
-  assert location.exchange(4, Acquire) == 3
-  assert location.exchange(5, Release) == 4
-  assert location.exchange(6, AcqRel) == 5
-  assert location.load == 6
+  doAssert location.exchange(2) == 1
+  doAssert location.exchange(3, Relaxed) == 2
+  doAssert location.exchange(4, Acquire) == 3
+  doAssert location.exchange(5, Release) == 4
+  doAssert location.exchange(6, AcqRel) == 5
+  doAssert location.load == 6
 
 block trivialCompareExchangeDoesExchange:
   var location: Atomic[int]
   var expected = 1
   location.store(1)
-  assert location.compareExchange(expected, 2)
-  assert expected == 1
-  assert location.load == 2
+  doAssert location.compareExchange(expected, 2)
+  doAssert expected == 1
+  doAssert location.load == 2
   expected = 2
-  assert location.compareExchange(expected, 3, Relaxed)
-  assert expected == 2
-  assert location.load == 3
+  doAssert location.compareExchange(expected, 3, Relaxed)
+  doAssert expected == 2
+  doAssert location.load == 3
   expected = 3
-  assert location.compareExchange(expected, 4, Acquire)
-  assert expected == 3
-  assert location.load == 4
+  doAssert location.compareExchange(expected, 4, Acquire)
+  doAssert expected == 3
+  doAssert location.load == 4
   expected = 4
-  assert location.compareExchange(expected, 5, Release)
-  assert expected == 4
-  assert location.load == 5
+  doAssert location.compareExchange(expected, 5, Release)
+  doAssert expected == 4
+  doAssert location.load == 5
   expected = 5
-  assert location.compareExchange(expected, 6, AcqRel)
-  assert expected == 5
-  assert location.load == 6
+  doAssert location.compareExchange(expected, 6, AcqRel)
+  doAssert expected == 5
+  doAssert location.load == 6
 
 block trivialCompareExchangeDoesNotExchange:
   var location: Atomic[int]
   var expected = 10
   location.store(1)
-  assert not location.compareExchange(expected, 2)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 2)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchange(expected, 3, Relaxed)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 3, Relaxed)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchange(expected, 4, Acquire)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 4, Acquire)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchange(expected, 5, Release)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 5, Release)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchange(expected, 6, AcqRel)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 6, AcqRel)
+  doAssert expected == 1
+  doAssert location.load == 1
 
 block trivialCompareExchangeSuccessFailureDoesExchange:
   var location: Atomic[int]
   var expected = 1
   location.store(1)
-  assert location.compareExchange(expected, 2, SeqCst, SeqCst)
-  assert expected == 1
-  assert location.load == 2
+  doAssert location.compareExchange(expected, 2, SeqCst, SeqCst)
+  doAssert expected == 1
+  doAssert location.load == 2
   expected = 2
-  assert location.compareExchange(expected, 3, Relaxed, Relaxed)
-  assert expected == 2
-  assert location.load == 3
+  doAssert location.compareExchange(expected, 3, Relaxed, Relaxed)
+  doAssert expected == 2
+  doAssert location.load == 3
   expected = 3
-  assert location.compareExchange(expected, 4, Acquire, Acquire)
-  assert expected == 3
-  assert location.load == 4
+  doAssert location.compareExchange(expected, 4, Acquire, Acquire)
+  doAssert expected == 3
+  doAssert location.load == 4
   expected = 4
-  assert location.compareExchange(expected, 5, Release, Release)
-  assert expected == 4
-  assert location.load == 5
+  doAssert location.compareExchange(expected, 5, Release, Release)
+  doAssert expected == 4
+  doAssert location.load == 5
   expected = 5
-  assert location.compareExchange(expected, 6, AcqRel, AcqRel)
-  assert expected == 5
-  assert location.load == 6
+  doAssert location.compareExchange(expected, 6, AcqRel, AcqRel)
+  doAssert expected == 5
+  doAssert location.load == 6
 
 block trivialCompareExchangeSuccessFailureDoesNotExchange:
   var location: Atomic[int]
   var expected = 10
   location.store(1)
-  assert not location.compareExchange(expected, 2, SeqCst, SeqCst)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 2, SeqCst, SeqCst)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchange(expected, 3, Relaxed, Relaxed)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 3, Relaxed, Relaxed)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchange(expected, 4, Acquire, Acquire)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 4, Acquire, Acquire)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchange(expected, 5, Release, Release)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 5, Release, Release)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchange(expected, 6, AcqRel, AcqRel)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchange(expected, 6, AcqRel, AcqRel)
+  doAssert expected == 1
+  doAssert location.load == 1
 
 block trivialCompareExchangeWeakDoesExchange:
   var location: Atomic[int]
   var expected = 1
   location.store(1)
-  assert location.compareExchangeWeak(expected, 2)
-  assert expected == 1
-  assert location.load == 2
+  doAssert location.compareExchangeWeak(expected, 2)
+  doAssert expected == 1
+  doAssert location.load == 2
   expected = 2
-  assert location.compareExchangeWeak(expected, 3, Relaxed)
-  assert expected == 2
-  assert location.load == 3
+  doAssert location.compareExchangeWeak(expected, 3, Relaxed)
+  doAssert expected == 2
+  doAssert location.load == 3
   expected = 3
-  assert location.compareExchangeWeak(expected, 4, Acquire)
-  assert expected == 3
-  assert location.load == 4
+  doAssert location.compareExchangeWeak(expected, 4, Acquire)
+  doAssert expected == 3
+  doAssert location.load == 4
   expected = 4
-  assert location.compareExchangeWeak(expected, 5, Release)
-  assert expected == 4
-  assert location.load == 5
+  doAssert location.compareExchangeWeak(expected, 5, Release)
+  doAssert expected == 4
+  doAssert location.load == 5
   expected = 5
-  assert location.compareExchangeWeak(expected, 6, AcqRel)
-  assert expected == 5
-  assert location.load == 6
+  doAssert location.compareExchangeWeak(expected, 6, AcqRel)
+  doAssert expected == 5
+  doAssert location.load == 6
 
 block trivialCompareExchangeWeakDoesNotExchange:
   var location: Atomic[int]
   var expected = 10
   location.store(1)
-  assert not location.compareExchangeWeak(expected, 2)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 2)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchangeWeak(expected, 3, Relaxed)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 3, Relaxed)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchangeWeak(expected, 4, Acquire)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 4, Acquire)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchangeWeak(expected, 5, Release)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 5, Release)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchangeWeak(expected, 6, AcqRel)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 6, AcqRel)
+  doAssert expected == 1
+  doAssert location.load == 1
 
 block trivialCompareExchangeWeakSuccessFailureDoesExchange:
   var location: Atomic[int]
   var expected = 1
   location.store(1)
-  assert location.compareExchangeWeak(expected, 2, SeqCst, SeqCst)
-  assert expected == 1
-  assert location.load == 2
+  doAssert location.compareExchangeWeak(expected, 2, SeqCst, SeqCst)
+  doAssert expected == 1
+  doAssert location.load == 2
   expected = 2
-  assert location.compareExchangeWeak(expected, 3, Relaxed, Relaxed)
-  assert expected == 2
-  assert location.load == 3
+  doAssert location.compareExchangeWeak(expected, 3, Relaxed, Relaxed)
+  doAssert expected == 2
+  doAssert location.load == 3
   expected = 3
-  assert location.compareExchangeWeak(expected, 4, Acquire, Acquire)
-  assert expected == 3
-  assert location.load == 4
+  doAssert location.compareExchangeWeak(expected, 4, Acquire, Acquire)
+  doAssert expected == 3
+  doAssert location.load == 4
   expected = 4
-  assert location.compareExchangeWeak(expected, 5, Release, Release)
-  assert expected == 4
-  assert location.load == 5
+  doAssert location.compareExchangeWeak(expected, 5, Release, Release)
+  doAssert expected == 4
+  doAssert location.load == 5
   expected = 5
-  assert location.compareExchangeWeak(expected, 6, AcqRel, AcqRel)
-  assert expected == 5
-  assert location.load == 6
+  doAssert location.compareExchangeWeak(expected, 6, AcqRel, AcqRel)
+  doAssert expected == 5
+  doAssert location.load == 6
 
 block trivialCompareExchangeWeakSuccessFailureDoesNotExchange:
   var location: Atomic[int]
   var expected = 10
   location.store(1)
-  assert not location.compareExchangeWeak(expected, 2, SeqCst, SeqCst)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 2, SeqCst, SeqCst)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchangeWeak(expected, 3, Relaxed, Relaxed)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 3, Relaxed, Relaxed)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchangeWeak(expected, 4, Acquire, Acquire)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 4, Acquire, Acquire)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchangeWeak(expected, 5, Release, Release)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 5, Release, Release)
+  doAssert expected == 1
+  doAssert location.load == 1
   expected = 10
-  assert not location.compareExchangeWeak(expected, 6, AcqRel, AcqRel)
-  assert expected == 1
-  assert location.load == 1
+  doAssert not location.compareExchangeWeak(expected, 6, AcqRel, AcqRel)
+  doAssert expected == 1
+  doAssert location.load == 1
 
 # Numerical operations
 
 block fetchAdd:
   var location: Atomic[int]
-  assert location.fetchAdd(1) == 0
-  assert location.fetchAdd(1, Relaxed) == 1
-  assert location.fetchAdd(1, Release) == 2
-  assert location.load == 3
+  doAssert location.fetchAdd(1) == 0
+  doAssert location.fetchAdd(1, Relaxed) == 1
+  doAssert location.fetchAdd(1, Release) == 2
+  doAssert location.load == 3
 
 block fetchSub:
   var location: Atomic[int]
-  assert location.fetchSub(1) == 0
-  assert location.fetchSub(1, Relaxed) == -1
-  assert location.fetchSub(1, Release) == -2
-  assert location.load == -3
+  doAssert location.fetchSub(1) == 0
+  doAssert location.fetchSub(1, Relaxed) == -1
+  doAssert location.fetchSub(1, Release) == -2
+  doAssert location.load == -3
 
 block fetchAnd:
   var location: Atomic[int]
@@ -243,20 +243,20 @@ block fetchAnd:
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchAnd(j) == i)
-      assert(location.load == i.bitand(j))
+      doAssert(location.fetchAnd(j) == i)
+      doAssert(location.load == i.bitand(j))
 
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchAnd(j, Relaxed) == i)
-      assert(location.load == i.bitand(j))
+      doAssert(location.fetchAnd(j, Relaxed) == i)
+      doAssert(location.load == i.bitand(j))
 
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchAnd(j, Release) == i)
-      assert(location.load == i.bitand(j))
+      doAssert(location.fetchAnd(j, Release) == i)
+      doAssert(location.load == i.bitand(j))
 
 block fetchOr:
   var location: Atomic[int]
@@ -264,20 +264,20 @@ block fetchOr:
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchOr(j) == i)
-      assert(location.load == i.bitor(j))
+      doAssert(location.fetchOr(j) == i)
+      doAssert(location.load == i.bitor(j))
 
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchOr(j, Relaxed) == i)
-      assert(location.load == i.bitor(j))
+      doAssert(location.fetchOr(j, Relaxed) == i)
+      doAssert(location.load == i.bitor(j))
 
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchOr(j, Release) == i)
-      assert(location.load == i.bitor(j))
+      doAssert(location.fetchOr(j, Release) == i)
+      doAssert(location.load == i.bitor(j))
 
 block fetchXor:
   var location: Atomic[int]
@@ -285,35 +285,35 @@ block fetchXor:
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchXor(j) == i)
-      assert(location.load == i.bitxor(j))
+      doAssert(location.fetchXor(j) == i)
+      doAssert(location.load == i.bitxor(j))
 
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchXor(j, Relaxed) == i)
-      assert(location.load == i.bitxor(j))
+      doAssert(location.fetchXor(j, Relaxed) == i)
+      doAssert(location.load == i.bitxor(j))
 
   for i in 0..16:
     for j in 0..16:
       location.store(i)
-      assert(location.fetchXor(j, Release) == i)
-      assert(location.load == i.bitxor(j))
+      doAssert(location.fetchXor(j, Release) == i)
+      doAssert(location.load == i.bitxor(j))
 
 block atomicInc:
   var location: Atomic[int]
   location.atomicInc
-  assert location.load == 1
+  doAssert location.load == 1
   location.atomicInc(1)
-  assert location.load == 2
+  doAssert location.load == 2
   location += 1
-  assert location.load == 3
+  doAssert location.load == 3
 
 block atomicDec:
   var location: Atomic[int]
   location.atomicDec
-  assert location.load == -1
+  doAssert location.load == -1
   location.atomicDec(1)
-  assert location.load == -2
+  doAssert location.load == -2
   location -= 1
-  assert location.load == -3
+  doAssert location.load == -3

--- a/tests/tsmartptrs.nim
+++ b/tests/tsmartptrs.nim
@@ -4,60 +4,60 @@ block:
   var a1: UniquePtr[int]
   var a2 = newUniquePtr(0)
 
-  assert $a1 == "nil"
-  assert a1.isNil
-  assert $a2 == "(val: 0)"
-  assert not a2.isNil
-  assert a2[] == 0
+  doAssert $a1 == "nil"
+  doAssert a1.isNil
+  doAssert $a2 == "(val: 0)"
+  doAssert not a2.isNil
+  doAssert a2[] == 0
 
   # UniquePtr can't be copied but can be moved
   let a3 = move a2
 
-  assert $a2 == "nil"
-  assert a2.isNil
+  doAssert $a2 == "nil"
+  doAssert a2.isNil
 
-  assert $a3 == "(val: 0)"
-  assert not a3.isNil
-  assert a3[] == 0
+  doAssert $a3 == "(val: 0)"
+  doAssert not a3.isNil
+  doAssert a3[] == 0
 
   a1 = newUniquePtr(int)
   a1[] = 1
-  assert a1[] == 1
+  doAssert a1[] == 1
   var a4 = newUniquePtr(string)
   a4[] = "hello world"
-  assert a4[] == "hello world"
+  doAssert a4[] == "hello world"
 
 block:
   var a1: SharedPtr[int]
   let a2 = newSharedPtr(0)
   let a3 = a2
 
-  assert $a1 == "nil"
-  assert a1.isNil
-  assert $a2 == "(val: 0)"
-  assert not a2.isNil
-  assert a2[] == 0
-  assert $a3 == "(val: 0)"
-  assert not a3.isNil
-  assert a3[] == 0
+  doAssert $a1 == "nil"
+  doAssert a1.isNil
+  doAssert $a2 == "(val: 0)"
+  doAssert not a2.isNil
+  doAssert a2[] == 0
+  doAssert $a3 == "(val: 0)"
+  doAssert not a3.isNil
+  doAssert a3[] == 0
 
   a1 = newSharedPtr(int)
   a1[] = 1
-  assert a1[] == 1
+  doAssert a1[] == 1
   var a4 = newSharedPtr(string)
   a4[] = "hello world"
-  assert a4[] == "hello world"
+  doAssert a4[] == "hello world"
 
 block:
   var a1: ConstPtr[float]
   let a2 = newConstPtr(0)
   let a3 = a2
 
-  assert $a1 == "nil"
-  assert a1.isNil
-  assert $a2 == "(val: 0)"
-  assert not a2.isNil
-  assert a2[] == 0
-  assert $a3 == "(val: 0)"
-  assert not a3.isNil
-  assert a3[] == 0
+  doAssert $a1 == "nil"
+  doAssert a1.isNil
+  doAssert $a2 == "(val: 0)"
+  doAssert not a2.isNil
+  doAssert a2[] == 0
+  doAssert $a3 == "(val: 0)"
+  doAssert not a3.isNil
+  doAssert a3[] == 0

--- a/tests/tsmartptrsleak.nim
+++ b/tests/tsmartptrsleak.nim
@@ -35,7 +35,7 @@ proc threadA() {.thread.} =
       var a: SharedPtr[TestObj] = newSharedPtr(unsafeIsolate TestObj())
       var b = a
       chan.send(b)
-      assert a.isNil == false # otherwise we don't copy a?
+      doAssert a.isNil == false # otherwise we don't copy a?
       when doSleep:
         os.sleep(1)
 


### PR DESCRIPTION
This is a tiny PR, just moves the subset of tests that use "assert" from using "assert" to "doAssert"

Some tests already use doAssert, some use assert.

For tests, they should be compileable as debug, release and danger build without losing validity. 
That makes doAssert the only valid choice.

I'm currently playing around with solidifying the test-suite (e.g. by adding valgrind checks or similar).
Those PR is somewhat of a prerequisite for that playing around since the test-suite should also be doing tests for -d:danger builds.