### PR TITLE
refactor channels.trySend/tryRecv and improve tests

### DIFF
--- a/tests/tchannels_cooperative.nim
+++ b/tests/tchannels_cooperative.nim
@@ -10,27 +10,27 @@ const
   sentmsg = "task sent"
 
 type
-  Payload = tuple[chan: ptr Chan[int16], idx: int16]
+  Payload = tuple[chan: Chan[int16], idx: int16]
 
 var
   sentmessages = newSeqOfCap[string](NTasks)
   receivedmessages = newSeqOfCap[int16](NTasks)
 
 # A prototype of a task executing thread
-proc runner(tasksCh: ptr Chan[Payload]) {.thread.} =
+proc runner(tasksCh: Chan[Payload]) {.thread.} =
   var p: Payload
   while true:
-    tasksCh[].recv(p) # Get a message from the main thread
+    tasksCh.recv(p) # Get a message from the main thread
     if p.idx == -1: break # Check for an ad hoc stop signal
     else:
       sleep(SleepDurationMS) # Hard work
-      p.chan[].send(p.idx) # Notify a consumer
+      p.chan.send(p.idx) # Notify a consumer
 
 # A single thread receiving result from runner threads
-proc consumer(args: tuple[resultsCh: ptr Chan[int16], tasks: int16]) {.thread.} =
+proc consumer(args: tuple[resultsCh: Chan[int16], tasks: int16]) {.thread.} =
   var idx: int16
   for _ in 0..<args.tasks: # We know the number of tasks and wait for them all
-    args.resultsCh[].recv(idx)
+    args.resultsCh.recv(idx)
     {.gcsafe.}: # Don't do this. Here we know it's an exclusive access
       receivedmessages.add(idx) # Store which task was completed
 
@@ -38,22 +38,22 @@ proc main(chanSize: Natural) =
   sentmessages.setLen(0)
   receivedmessages.setLen(0)
   var
-    taskThreads = newSeq[Thread[ptr Chan[Payload]]](countProcessors())
+    taskThreads = newSeq[Thread[Chan[Payload]]](countProcessors())
     tasksCh = newChan[Payload](chanSize)
-    consumerTh: Thread[(ptr Chan[int16], int16)]
+    consumerTh: Thread[(Chan[int16], int16)]
     resultsCh = newChan[int16](chanSize)
 
   # Consumer must be ready first to not block
-  createThread(consumerTh, consumer, (resultsCh.addr, NTasks))
+  createThread(consumerTh, consumer, (resultsCh, NTasks))
   # Start runner threads
-  for i in 0..high(taskThreads): createThread(taskThreads[i], runner, tasksCh.addr)
+  for i in 0..high(taskThreads): createThread(taskThreads[i], runner, tasksCh)
   # Loop iterating fake data
-  for idx in 0'i16..<NTasks: 
-    tasksCh.send((resultsCh.addr, idx))
+  for idx in 0'i16..<NTasks:
+    tasksCh.send((resultsCh, idx))
     sentmessages.add(sentmsg)
 
   for _ in taskThreads: # Stopping worker threads
-    tasksCh.send((resultsCh.addr, -1'i16)) # A thread can't get more than 1 stop signal
+    tasksCh.send((resultsCh, -1'i16)) # A thread can't get more than 1 stop signal
   joinThreads(taskThreads)
   joinThread(consumerTh)
 
@@ -69,10 +69,10 @@ template runTests(bufferSize: Positive) =
   var set = {0..NTasks-1}
   for i in receivedmessages: set.excl(i)
   doAssert set == {}
-  
-  
+
+
 block buffered_channels:
-  runTests(bufferSize = 2) 
+  runTests(bufferSize = 2)
 
 block unbuffered_channels:
   runTests(bufferSize = 1)

--- a/tests/tchannels_singlebuf.nim
+++ b/tests/tchannels_singlebuf.nim
@@ -51,6 +51,7 @@ block send_tryRecv:
   let src = Message
 
   createThread(thread, test, chan)
+  sleep 1
   chan.send(src)
 
   thread.joinThread()

--- a/tests/tchannels_singlebuf.nim
+++ b/tests/tchannels_singlebuf.nim
@@ -2,7 +2,7 @@
 ## https://github.com/nim-lang/threading/pull/27#issue-1652851878
 ## Also tests `trySend` and `tryRecv` templates.
 
-import threading/channels
+import threading/channels, std/os
 const Message = "Hello"
 
 block trySend_recv:
@@ -23,6 +23,7 @@ block trySend_recv:
   var dest: string
 
   createThread(thread, test, chan)
+  sleep 1
   # Receive the dummy message to make room for the real message
   discard chan.recv()
 

--- a/tests/tchannels_singlebuf.nim
+++ b/tests/tchannels_singlebuf.nim
@@ -10,7 +10,7 @@ block trySend_recv:
 
   proc test(chan: Chan[string]) {.thread.} =
     var notSent = true
-    var msg = Message
+    let msg = Message
     while notSent:
       notSent = not chan.trySend(msg)
       if notSent:
@@ -19,14 +19,15 @@ block trySend_recv:
   var chan = newChan[string](elements = 1)
   # Fill the channel before spawning the thread
   chan.send("Dummy message")
-  var thread: Thread[Chan[string]]
-  var dest: string
 
+  var thread: Thread[Chan[string]]
   createThread(thread, test, chan)
-  sleep 1
+  sleep 10
+
   # Receive the dummy message to make room for the real message
   discard chan.recv()
 
+  var dest: string
   chan.recv(dest)
   doAssert dest == Message
 
@@ -47,11 +48,12 @@ block send_tryRecv:
     doAssert msg == Message
 
   var chan = newChan[string](elements = 1)
-  var thread: Thread[Chan[string]]
-  let src = Message
 
+  var thread: Thread[Chan[string]]
   createThread(thread, test, chan)
-  sleep 1
+  sleep 10
+
+  let src = Message
   chan.send(src)
 
   thread.joinThread()

--- a/tests/tsmartptrsleak.nim
+++ b/tests/tsmartptrsleak.nim
@@ -1,7 +1,7 @@
 import threading/smartptrs
 import std/isolation
 import std/locks
-import threading/atomics
+import std/atomics
 import threading/channels
 
 var
@@ -12,10 +12,10 @@ type
 
 when defined(nimAllowNonVarDestructor):
   proc `=destroy`(obj: TestObj) =
-    discard freeCounts.fetchAdd(1, Release)
+    discard freeCounts.fetchAdd(1, moRelease)
 else:
   proc `=destroy`(obj: var TestObj) =
-    discard freeCounts.fetchAdd(1, Release)
+    discard freeCounts.fetchAdd(1, moRelease)
 
 var
   thr: array[0..1, Thread[void]]
@@ -50,6 +50,6 @@ createThread(thr[0], threadA)
 createThread(thr[1], threadB)
 joinThreads(thr)
 
-echo "freeCounts: got: ", $int(freeCounts), " expected: ", N
+echo "freeCounts: got: ", load(freeCounts, moRelaxed), " expected: ", N
 echo ""
-assert freeCounts.load(Acquire) == N
+assert freeCounts.load(moRelaxed) == N

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -286,7 +286,7 @@ proc `=copy`*[T](dest: var Chan[T], src: Chan[T]) =
   `=destroy`(dest)
   dest.d = src.d
 
-proc trySend*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
+proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
   ## Tries to send the message `src` to the channel `c`.
   ##
   ## The memory of `src` is moved, not copied. 
@@ -308,8 +308,7 @@ proc trySend*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
 template trySend*[T](c: Chan[T], src: T): bool =
   ## Helper template for `trySend <#trySend,Chan[T],sinkIsolated[T]>`_.
   mixin isolate
-  var p = isolate(src)
-  trySend(c, p)
+  trySend(c, isolate(src))
 
 proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## Tries to receive a message from the channel `c` and fill `dst` with its value.

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -306,6 +306,10 @@ proc trySend*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
 
 template trySend*[T](c: Chan[T], src: T): bool =
   ## Helper template for `trySend <#trySend,Chan[T],sinkIsolated[T]>`_.
+  ##
+  ## .. warning:: This template creates a new copy of `src` on each call.
+  ##    For repeated sends of the same value, consider using the `trySend`
+  ##    proc with a pre-isolated value to avoid unnecessary copying.
   mixin isolate
   var p = isolate(src)
   trySend(c, p)

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -294,11 +294,6 @@ proc trySend*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ## The memory of `src` is moved, not copied. 
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
-  ## 
-  ## .. warning:: Blocking is still possible if another thread uses the blocking
-  ##    version of the `send proc`_ / `recv proc`_ and waits for the 
-  ##    data/space to appear in the channel, thus holding the internal lock to 
-  ##    channel's buffer.
   ##
   ## Returns `false` if the message was not sent because the number of pending
   ## messages in the channel exceeded its capacity.
@@ -321,10 +316,6 @@ proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## 
   ## Doesn't block waiting for messages in the channel to become available.
   ## Instead returns after an attempt to receive a message was made.
-  ## 
-  ## .. warning:: Blocking is still possible if another thread uses the blocking
-  ##    version of the `send proc`_ / `recv proc`_ and waits for the data/space to 
-  ##    appear in the channel, thus holding the internal lock to channel's buffer.
   ## 
   ## Returns `false` and does not change `dist` if no message was received.
   channelReceive(c.d, dst.addr, sizeof(T), false)

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -301,7 +301,7 @@ proc trySend*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ## Returns `false` if the message was not sent because the number of pending
   ## messages in the channel exceeded its capacity.
   var data = src.extract
-  result = channelSend(c.d, data.unsafeAddr, sizeof(T), false)
+  result = channelSend(c.d, data.addr, sizeof(T), false)
   if result:
     wasMoved(data)
 
@@ -335,7 +335,7 @@ proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
   var data = src.extract
   when defined(gcOrc) and defined(nimSafeOrcSend):
     GC_runOrc()
-  discard channelSend(c.d, data.unsafeAddr, sizeof(T), true)
+  discard channelSend(c.d, data.addr, sizeof(T), true)
   wasMoved(data)
 
 template send*[T](c: Chan[T]; src: T) =

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -317,7 +317,9 @@ template trySend*[T](c: Chan[T], src: T): bool =
 proc tryTake*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ## Tries to send the message `src` to the channel `c`.
   ##
-  ## The memory of `src` is moved directly.
+  ## The memory of `src` is moved directly. Be careful not to reuse `src` afterwards.
+  ## This proc is suitable when `src` cannot be copied.
+  ##
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
   ##

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -187,8 +187,9 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
 
   when not blocking:
     if chan.isFull(): return false
-
-  acquire(chan.lock)
+    if not tryAcquire(chan.lock): return false
+  else:
+    acquire(chan.lock)
 
   # check for when another thread was faster to fill
   when blocking:
@@ -221,8 +222,9 @@ proc channelReceive(chan: ChannelRaw, data: pointer, size: int, blocking: static
 
   when not blocking:
     if chan.isEmpty(): return false
-
-  acquire(chan.lock)
+    if not tryAcquire(chan.lock): return false
+  else:
+    acquire(chan.lock)
 
   # check for when another thread was faster to empty
   when blocking:

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -28,9 +28,9 @@
 ## the underlying resources and synchronization. It has to be initialized using
 ## the `newChan` proc. Sending and receiving operations are provided by the
 ## blocking `send` and `recv` procs, and non-blocking `trySend` and `tryRecv`
-## procs. Send operations add messages to the channel, receiving operations 
+## procs. Send operations add messages to the channel, receiving operations
 ## remove them.
-## 
+##
 ## See also:
 ## * [std/isolation](https://nim-lang.org/docs/isolation.html)
 ##
@@ -307,7 +307,8 @@ template trySend*[T](c: Chan[T], src: T): bool =
   ## Helper template for `trySend <#trySend,Chan[T],sinkIsolated[T]>`_.
   ##
   ## .. warning:: For repeated sends of the same value, consider using the
-  ## `trySendMut` proc with a pre-isolated value to avoid unnecessary copying.
+  ##    `tryTake <#tryTake,Chan[T],varIsolated[T]>`_ proc with a pre-isolated
+  ##    value to avoid unnecessary copying.
   mixin isolate
   trySend(c, isolate(src))
 
@@ -332,7 +333,7 @@ proc tryTake*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
 
 proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## Tries to receive a message from the channel `c` and fill `dst` with its value.
-  ## 
+  ##
   ## Doesn't block waiting for messages in the channel to become available.
   ## Instead returns after an attempt to receive a message was made.
   ##
@@ -344,11 +345,11 @@ proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   channelReceive(c.d, dst.addr, sizeof(T), false)
 
 proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
-  ## Sends the message `src` to the channel `c`. 
+  ## Sends the message `src` to the channel `c`.
   ## This blocks the sending thread until `src` was successfully sent.
-  ## 
-  ## The memory of `src` is moved, not copied. 
-  ## 
+  ##
+  ## The memory of `src` is moved, not copied.
+  ##
   ## If the channel is already full with messages this will block the thread until
   ## messages from the channel are removed.
   when defined(gcOrc) and defined(nimSafeOrcSend):
@@ -362,16 +363,16 @@ template send*[T](c: Chan[T]; src: T) =
   send(c, isolate(src))
 
 proc recv*[T](c: Chan[T], dst: var T) {.inline.} =
-  ## Receives a message from the channel `c` and fill `dst` with its value. 
-  ## 
+  ## Receives a message from the channel `c` and fill `dst` with its value.
+  ##
   ## This blocks the receiving thread until a message was successfully received.
-  ## 
+  ##
   ## If the channel does not contain any messages this will block the thread until
   ## a message get sent to the channel.
   discard channelReceive(c.d, dst.addr, sizeof(T), true)
 
 proc recv*[T](c: Chan[T]): T {.inline.} =
-  ## Receives a message from the channel. 
+  ## Receives a message from the channel.
   ## A version of `recv`_ that returns the message.
   discard channelReceive(c.d, result.addr, sizeof(result), true)
 
@@ -388,9 +389,8 @@ proc peek*[T](c: Chan[T]): int {.inline.} =
 
 proc newChan*[T](elements: Positive = 30): Chan[T] =
   ## An initialization procedure, necessary for acquiring resources and
-  ## initializing internal state of the channel. 
-  ## 
-  ## `elements` is the capacity of the channel and thus how many messages it can hold 
+  ## initializing internal state of the channel.
+  ##
+  ## `elements` is the capacity of the channel and thus how many messages it can hold
   ## before it refuses to accept any further messages.
-  assert elements >= 1, "Elements must be positive!"
   result = Chan[T](d: allocChannel(sizeof(T), elements))

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -307,6 +307,7 @@ proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
 
 template trySend*[T](c: Chan[T], src: T): bool =
   ## Helper template for `trySend <#trySend,Chan[T],sinkIsolated[T]>`_.
+  mixin isolate
   trySend(c, isolate(src))
 
 proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
@@ -338,6 +339,7 @@ proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
 
 template send*[T](c: Chan[T]; src: T) =
   ## Helper template for `send`.
+  mixin isolate
   send(c, isolate(src))
 
 proc recv*[T](c: Chan[T], dst: var T) {.inline.} =

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -291,7 +291,7 @@ proc `=copy`*[T](dest: var Chan[T], src: Chan[T]) =
 proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
   ## Tries to send the message `src` to the channel `c`.
   ##
-  ## The memory of `src` is copied.
+  ## The memory of `src` be moved if possible.
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
   ##
@@ -316,7 +316,7 @@ template trySend*[T](c: Chan[T], src: T): bool =
 proc trySendMut*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ## Tries to send the message `src` to the channel `c`.
   ##
-  ## The memory of `src` is moved, not copied.
+  ## The memory of `src` is moved directly.
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
   ##

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -328,11 +328,10 @@ proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
   ## 
   ## If the channel is already full with messages this will block the thread until
   ## messages from the channel are removed.
-  var data = src.extract
   when defined(gcOrc) and defined(nimSafeOrcSend):
     GC_runOrc()
-  discard channelSend(c.d, data.addr, sizeof(T), true)
-  wasMoved(data)
+  discard channelSend(c.d, src.addr, sizeof(T), true)
+  wasMoved(src)
 
 template send*[T](c: Chan[T]; src: T) =
   ## Helper template for `send`.

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -291,7 +291,7 @@ proc `=copy`*[T](dest: var Chan[T], src: Chan[T]) =
 proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
   ## Tries to send the message `src` to the channel `c`.
   ##
-  ## The memory of `src` be moved if possible.
+  ## The memory of `src` will be moved if possible.
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
   ##
@@ -313,7 +313,7 @@ template trySend*[T](c: Chan[T], src: T): bool =
   mixin isolate
   trySend(c, isolate(src))
 
-proc trySendMut*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
+proc tryTake*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ## Tries to send the message `src` to the channel `c`.
   ##
   ## The memory of `src` is moved directly.

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -187,9 +187,8 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
 
   when not blocking:
     if chan.isFull(): return false
-    if not tryAcquire(chan.lock): return false
-  else:
-    acquire(chan.lock)
+
+  acquire(chan.lock)
 
   # check for when another thread was faster to fill
   when blocking:
@@ -222,9 +221,8 @@ proc channelReceive(chan: ChannelRaw, data: pointer, size: int, blocking: static
 
   when not blocking:
     if chan.isEmpty(): return false
-    if not tryAcquire(chan.lock): return false
-  else:
-    acquire(chan.lock)
+
+  acquire(chan.lock)
 
   # check for when another thread was faster to empty
   when blocking:

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -286,7 +286,7 @@ proc `=copy`*[T](dest: var Chan[T], src: Chan[T]) =
   `=destroy`(dest)
   dest.d = src.d
 
-proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
+proc trySend*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ## Tries to send the message `src` to the channel `c`.
   ##
   ## The memory of `src` is moved, not copied. 
@@ -308,7 +308,8 @@ proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
 template trySend*[T](c: Chan[T], src: T): bool =
   ## Helper template for `trySend <#trySend,Chan[T],sinkIsolated[T]>`_.
   mixin isolate
-  trySend(c, isolate(src))
+  var p = isolate(src)
+  trySend(c, p)
 
 proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## Tries to receive a message from the channel `c` and fill `dst` with its value.

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -293,9 +293,6 @@ proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
   ##
-  ## .. warning:: Blocking may occur if another thread holds the internal lock on
-  ##    the channel's buffer, causing the thread to wait until the lock is released.
-  ##
   ## .. warning:: In high-concurrency situations, consider using an exponential
   ##    backoff strategy to reduce contention and improve the success rate of
   ##    operations.
@@ -323,9 +320,6 @@ proc tryTake*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
   ##
-  ## .. warning:: Blocking may occur if another thread holds the internal lock on
-  ##    the channel's buffer, causing the thread to wait until the lock is released.
-  ##
   ## .. warning:: In high-concurrency situations, consider using an exponential
   ##    backoff strategy to reduce contention and improve the success rate of
   ##    operations.
@@ -342,9 +336,6 @@ proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## Doesn't block waiting for messages in the channel to become available.
   ## Instead returns after an attempt to receive a message was made.
   ##
-  ## .. warning:: Blocking may occur if another thread holds the internal lock on
-  ##    the channel's buffer, causing the thread to wait until the lock is released.
-  ## 
   ## .. warning:: In high-concurrency situations, consider using an exponential
   ##    backoff strategy to reduce contention and improve the success rate of
   ##    operations.

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -187,9 +187,8 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
 
   when not blocking:
     if chan.isFull(): return false
-    if not tryAcquire(chan.lock): return false
-  else:
-    acquire(chan.lock)
+
+  acquire(chan.lock)
 
   # check for when another thread was faster to fill
   when blocking:
@@ -222,9 +221,8 @@ proc channelReceive(chan: ChannelRaw, data: pointer, size: int, blocking: static
 
   when not blocking:
     if chan.isEmpty(): return false
-    if not tryAcquire(chan.lock): return false
-  else:
-    acquire(chan.lock)
+
+  acquire(chan.lock)
 
   # check for when another thread was faster to empty
   when blocking:
@@ -295,6 +293,9 @@ proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
   ##
+  ## .. warning:: Blocking may occur if another thread holds the internal lock on
+  ##    the channel's buffer, causing the thread to wait until the lock is released.
+  ##
   ## .. warning:: In high-concurrency situations, consider using an exponential
   ##    backoff strategy to reduce contention and improve the success rate of
   ##    operations.
@@ -320,6 +321,9 @@ proc tryTake*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ## Doesn't block waiting for space in the channel to become available.
   ## Instead returns after an attempt to send a message was made.
   ##
+  ## .. warning:: Blocking may occur if another thread holds the internal lock on
+  ##    the channel's buffer, causing the thread to wait until the lock is released.
+  ##
   ## .. warning:: In high-concurrency situations, consider using an exponential
   ##    backoff strategy to reduce contention and improve the success rate of
   ##    operations.
@@ -335,6 +339,9 @@ proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## 
   ## Doesn't block waiting for messages in the channel to become available.
   ## Instead returns after an attempt to receive a message was made.
+  ##
+  ## .. warning:: Blocking may occur if another thread holds the internal lock on
+  ##    the channel's buffer, causing the thread to wait until the lock is released.
   ## 
   ## .. warning:: In high-concurrency situations, consider using an exponential
   ##    backoff strategy to reduce contention and improve the success rate of


### PR DESCRIPTION
This PR refactors the logic for the non-blocking channels as well as the relevant test.

- Forces trySend calls in tchannels_singlebuf.nim to run multiple times before succeeding.
- Changes the signature to `proc trySend*[T](c: Chan[T], src: var Isolated[T]): bool` as discussed in the comments.
- Reworks the glue logic between Chan and ChannelRaw in send/trySend to prevent copies (use Isolated[T] directly).
- Add a warning message to the trySend template to inform the user about unwanted copies.
- Use tryAcquire instead of acquire for the non-blocking variants. A warning about increased lock-contention is added.
- Removes warnings messages from the trySend/tryRecv docs about blocking that are incorrect (see comments).
- recvIso is also made to use Isolated[T] directly as this fixes receiving ref objects.
- remove useless assert in newChan, since this condition is covered by the Positive range type.
