### PR TITLE
Include omission from previous PR

### DIFF
--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -374,14 +374,12 @@ proc recv*[T](c: Chan[T], dst: var T) {.inline.} =
 proc recv*[T](c: Chan[T]): T {.inline.} =
   ## Receives a message from the channel.
   ## A version of `recv`_ that returns the message.
-  discard channelReceive(c.d, result.addr, sizeof(result), true)
+  discard channelReceive(c.d, result.addr, sizeof(T), true)
 
 proc recvIso*[T](c: Chan[T]): Isolated[T] {.inline.} =
   ## Receives a message from the channel.
   ## A version of `recv`_ that returns the message and isolates it.
-  var dst: T
-  discard channelReceive(c.d, dst.addr, sizeof(T), true)
-  result = isolate(dst)
+  discard channelReceive(c.d, result.addr, sizeof(T), true)
 
 proc peek*[T](c: Chan[T]): int {.inline.} =
   ## Returns an estimation of the current number of messages held by the channel.

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -307,7 +307,7 @@ template trySend*[T](c: Chan[T], src: T): bool =
   ## Helper template for `trySend <#trySend,Chan[T],sinkIsolated[T]>`_.
   ##
   ## .. warning:: For repeated sends of the same value, consider using the
-  ##    `tryTake <#tryTake,Chan[T],varIsolated[T]>`_ proc with a pre-isolated
+  ##    `tryTake <#tryTake,Chan[T],Isolated[T]>`_ proc with a pre-isolated
   ##    value to avoid unnecessary copying.
   mixin isolate
   trySend(c, isolate(src))


### PR DESCRIPTION
I accidentally missed the following change from my previous PR:

recvIso is also made to use Isolated[T] directly as this fixes receiving ref objects.

Meaning this now compiles:

```nim
type
  Foo = ref object
    data: int

var chan = newChan[Foo]()

block example_blocking:
  # This proc will be run in another thread.
  proc basicWorker() =
    chan.send(Foo(data: 4))

  # Launch the worker.
  var worker: Thread[void]
  createThread(worker, basicWorker)

  # Block until the message arrives, then print it out.
  var dest: Isolated[Foo]
  dest = chan.recvIso()
  echo dest.extract().data

  # Wait for the thread to exit before moving on to the next example.
  worker.joinThread()
```