### PR TITLE
Adding RwLock inplace initialization

### DIFF
--- a/threading/rwlock.nim
+++ b/threading/rwlock.nim
@@ -56,6 +56,11 @@ else:
 proc `=sink`*(dest: var RwLock; source: RwLock) {.error.}
 proc `=copy`*(dest: var RwLock; source: RwLock) {.error.}
 
+proc init*(rw: var RwLock) =
+  zeroMem(addr rw, sizeof(RwLock))
+  initCond(rw.c)
+  initLock(rw.L)
+
 proc createRwLock*(): RwLock =
   result = default(RwLock)
   initCond(result.c)


### PR DESCRIPTION
Right now an object with an `RwLock` field can't be properly initialized (`myobj.rwLock = createRwLock()` fails due to a deleted move constructor). This PR addresses this by introducing an in-place initializer (`init(myobj.rwLock)`).