### PR TITLE
Implement isUniqueRef to SharedPtr

### DIFF
--- a/tests/tsmartptrs.nim
+++ b/tests/tsmartptrs.nim
@@ -41,12 +41,16 @@ block:
   doAssert not a3.isNil
   doAssert a3[] == 0
 
+  doAssert a1.isUniqueRef() == true
   a1 = newSharedPtr(int)
   a1[] = 1
   doAssert a1[] == 1
   var a4 = newSharedPtr(string)
   a4[] = "hello world"
   doAssert a4[] == "hello world"
+  doAssert a4.isUniqueRef() == true
+  var a4p = a4
+  doAssert a4.isUniqueRef() == false
 
 block:
   var a1: ConstPtr[float]

--- a/tests/tsmartptrs.nim
+++ b/tests/tsmartptrs.nim
@@ -41,16 +41,16 @@ block:
   doAssert not a3.isNil
   doAssert a3[] == 0
 
-  doAssert a1.isUniqueRef() == true
+  doAssert a1.isUniqueRef()
   a1 = newSharedPtr(int)
   a1[] = 1
   doAssert a1[] == 1
   var a4 = newSharedPtr(string)
   a4[] = "hello world"
   doAssert a4[] == "hello world"
-  doAssert a4.isUniqueRef() == true
+  doAssert a4.isUniqueRef()
   var a4p = a4
-  doAssert a4.isUniqueRef() == false
+  doAssert(not a4.isUniqueRef())
 
 block:
   var a1: ConstPtr[float]

--- a/threading.nimble
+++ b/threading.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Araq"
 description   = "New threading primitives for --mm:arc/orc: atomics, channels, smart pointers and wait groups."
 license       = "MIT"

--- a/threading/smartptrs.nim
+++ b/threading/smartptrs.nim
@@ -151,6 +151,12 @@ proc `[]=`*[T](p: SharedPtr[T], val: sink Isolated[T]) {.inline.} =
 template `[]=`*[T](p: SharedPtr[T]; val: T) =
   `[]=`(p, isolate(val))
 
+proc isUniqueRef*[T](p: SharedPtr[T]): bool =
+  if p.val == nil:
+    return true
+  p.val.counter.load(moAcquireRelease) == 0
+  
+
 proc `$`*[T](p: SharedPtr[T]): string {.inline.} =
   if p.val == nil: "nil"
   else: "(val: " & $p.val.value & ")"


### PR DESCRIPTION
This helps with cases where you might want to do something when the SharedPtr is no longer shared.