### PR TITLE
Add `overwrite` option to channel send to enable ring-buffer like behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 nimcache/
 nimblecache/
 htmldocs/
-tests/tsmartptrsleak
-tests/tchannels_simple
+*
+!*/
+!*.*
+*.dSYM/

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -8,7 +8,6 @@ suite "Ring Buffer Channel Tests":
   test "Non-blocking ring buffer behavior":
     
     proc fillBuffer(n: int): seq[int] =
-      echo "\nfillBuffer ", n
       var chan = newChan[int](BufferSize, overwrite = true)
       # Fill the buffer
       for i in 0..<BufferSize+n:
@@ -30,3 +29,7 @@ suite "Ring Buffer Channel Tests":
     check fillBuffer(2) == @[2, 3, 4]
     check fillBuffer(3) == @[3, 4, 5]
     check fillBuffer(4) == @[4, 5, 6]
+    check fillBuffer(5) == @[5, 6, 7]
+    check fillBuffer(6) == @[6, 7, 8]
+    check fillBuffer(7) == @[7, 8, 9]
+    check fillBuffer(8) == @[8, 9, 10]

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -1,0 +1,27 @@
+import threading/channels
+import std/unittest
+
+const
+  BufferSize = 3
+
+suite "Ring Buffer Channel Tests":
+  test "Non-blocking ring buffer behavior":
+    var chan = newChan[int](BufferSize, overwrite = true)
+    
+    # Fill the buffer
+    for i in 0..<BufferSize:
+      check chan.trySend(i)
+    
+    # Send one more - should overwrite oldest value
+    discard chan.trySend(BufferSize)
+    
+    # Receive values - should get BufferSize as first value
+    var values: seq[int]
+    for i in 0..<BufferSize:
+      var x: int
+      check chan.tryRecv(x)
+      values.add(x)
+    
+    # Verify we got the most recent values
+    check values == @[1, 2, BufferSize]
+

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -11,7 +11,7 @@ suite "Ring Buffer Channel Tests":
       var chan = newChan[int](BufferSize, overwrite = true)
       # Fill the buffer
       for i in 0..<BufferSize+n:
-        check chan.trySend(i)
+        chan.send(i)
       
       # Receive values - should get BufferSize as first value
       var values: seq[int]

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -9,11 +9,8 @@ suite "Ring Buffer Channel Tests":
     var chan = newChan[int](BufferSize, overwrite = true)
     
     # Fill the buffer
-    for i in 0..<BufferSize:
+    for i in 0..<BufferSize+1:
       check chan.trySend(i)
-    
-    # Send one more - should overwrite oldest value
-    discard chan.trySend(BufferSize)
     
     # Receive values - should get BufferSize as first value
     var values: seq[int]
@@ -26,45 +23,26 @@ suite "Ring Buffer Channel Tests":
     check values == @[BufferSize, 1, 2]
   
   test "Non-blocking ring buffer behavior with 2 elements":
-    var chan = newChan[int](BufferSize, overwrite = true)
     
-    # Fill the buffer
-    for i in 0..<BufferSize+1:
-      check chan.trySend(i)
+    proc fillBuffer(n: int): seq[int] =
+      var chan = newChan[int](BufferSize, overwrite = true)
+      # Fill the buffer
+      for i in 0..<BufferSize+n:
+        check chan.trySend(i)
+      
+      # Receive values - should get BufferSize as first value
+      var values: seq[int]
+      for i in 0..<BufferSize:
+        var x: int
+        if not chan.tryRecv(x):
+          break
+        values.add(x)
+      
+      # Verify we got the most recent values
+      result = values
     
-    # Send one more - should overwrite oldest value
-    discard chan.trySend(BufferSize)
-    
-    # Receive values - should get BufferSize as first value
-    var values: seq[int]
-    for i in 0..<BufferSize:
-      var x: int
-      check chan.tryRecv(x)
-      values.add(x)
-    
-    # Verify we got the most recent values
-    check values == @[BufferSize, BufferSize+1, 2]
-
-  test "Multiple overwrites":
-    var chan = newChan[int](BufferSize, overwrite = true)
-    
-    # Fill the buffer
-    for i in 0..<BufferSize:
-      discard chan.trySend(i)
-    
-    # Send multiple values that should overwrite
-    for i in 0..<BufferSize:
-      discard chan.trySend(BufferSize + i)
-    
-    # Receive values - should get the most recent values
-    var values: seq[int]
-    for i in 0..<BufferSize:
-      var x: int
-      let res = chan.tryRecv(x)
-      if not res:
-        break
-      values.add(x)
-    
-    # Verify we got the most recent values
-    check values == @[BufferSize + 1, BufferSize + 2, BufferSize + 3]
-  
+    check fillBuffer(0) == @[0, 1, 2]
+    check fillBuffer(1) == @[3, 1, 2]
+    check fillBuffer(2) == @[3, 4, 2]
+    check fillBuffer(3) == @[3, 4, 5]
+    check fillBuffer(4) == @[6, 4, 5]

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -8,10 +8,10 @@ suite "Ring Buffer Channel Tests":
   test "Non-blocking ring buffer behavior":
     
     proc fillBuffer(n: int): seq[int] =
-      var chan = newChan[int](BufferSize, overwrite = true)
+      var chan = newChan[int](BufferSize)
       # Fill the buffer
       for i in 0..<BufferSize+n:
-        chan.send(i)
+        chan.send(i, overwrite = true)
       
       # Receive values - should get BufferSize as first value
       var values: seq[int]
@@ -35,9 +35,9 @@ suite "Ring Buffer Channel Tests":
     check fillBuffer(8) == @[8, 9, 10]
 
   test "Non-blocking ring buffer behavior with size 1":
-    var chan = newChan[int](1, overwrite = true)
-    chan.send(1)
-    chan.send(2)
+    var chan = newChan[int](1)
+    chan.send(1, overwrite = true)
+    chan.send(2, overwrite = true)
     var x: int
     check chan.tryRecv(x)
     check x == 2

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -33,3 +33,11 @@ suite "Ring Buffer Channel Tests":
     check fillBuffer(6) == @[6, 7, 8]
     check fillBuffer(7) == @[7, 8, 9]
     check fillBuffer(8) == @[8, 9, 10]
+
+  test "Non-blocking ring buffer behavior with size 1":
+    var chan = newChan[int](1, overwrite = true)
+    chan.send(1)
+    chan.send(2)
+    var x: int
+    check chan.tryRecv(x)
+    check x == 2

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -23,5 +23,48 @@ suite "Ring Buffer Channel Tests":
       values.add(x)
     
     # Verify we got the most recent values
-    check values == @[1, 2, BufferSize]
+    check values == @[BufferSize, 1, 2]
+  
+  test "Non-blocking ring buffer behavior with 2 elements":
+    var chan = newChan[int](BufferSize, overwrite = true)
+    
+    # Fill the buffer
+    for i in 0..<BufferSize+1:
+      check chan.trySend(i)
+    
+    # Send one more - should overwrite oldest value
+    discard chan.trySend(BufferSize)
+    
+    # Receive values - should get BufferSize as first value
+    var values: seq[int]
+    for i in 0..<BufferSize:
+      var x: int
+      check chan.tryRecv(x)
+      values.add(x)
+    
+    # Verify we got the most recent values
+    check values == @[BufferSize, BufferSize+1, 2]
 
+  test "Multiple overwrites":
+    var chan = newChan[int](BufferSize, overwrite = true)
+    
+    # Fill the buffer
+    for i in 0..<BufferSize:
+      discard chan.trySend(i)
+    
+    # Send multiple values that should overwrite
+    for i in 0..<BufferSize:
+      discard chan.trySend(BufferSize + i)
+    
+    # Receive values - should get the most recent values
+    var values: seq[int]
+    for i in 0..<BufferSize:
+      var x: int
+      let res = chan.tryRecv(x)
+      if not res:
+        break
+      values.add(x)
+    
+    # Verify we got the most recent values
+    check values == @[BufferSize + 1, BufferSize + 2, BufferSize + 3]
+  

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -11,7 +11,7 @@ suite "Ring Buffer Channel Tests":
       var chan = newChan[int](BufferSize)
       # Fill the buffer
       for i in 0..<BufferSize+n:
-        chan.send(i, overwrite = true)
+        chan.push(i)
       
       # Receive values - should get BufferSize as first value
       var values: seq[int]
@@ -36,8 +36,8 @@ suite "Ring Buffer Channel Tests":
 
   test "Non-blocking ring buffer behavior with size 1":
     var chan = newChan[int](1)
-    chan.send(1, overwrite = true)
-    chan.send(2, overwrite = true)
+    chan.push(1)
+    chan.push(2)
     var x: int
     check chan.tryRecv(x)
     check x == 2

--- a/tests/tchannels_ring.nim
+++ b/tests/tchannels_ring.nim
@@ -6,25 +6,9 @@ const
 
 suite "Ring Buffer Channel Tests":
   test "Non-blocking ring buffer behavior":
-    var chan = newChan[int](BufferSize, overwrite = true)
-    
-    # Fill the buffer
-    for i in 0..<BufferSize+1:
-      check chan.trySend(i)
-    
-    # Receive values - should get BufferSize as first value
-    var values: seq[int]
-    for i in 0..<BufferSize:
-      var x: int
-      check chan.tryRecv(x)
-      values.add(x)
-    
-    # Verify we got the most recent values
-    check values == @[BufferSize, 1, 2]
-  
-  test "Non-blocking ring buffer behavior with 2 elements":
     
     proc fillBuffer(n: int): seq[int] =
+      echo "\nfillBuffer ", n
       var chan = newChan[int](BufferSize, overwrite = true)
       # Fill the buffer
       for i in 0..<BufferSize+n:
@@ -42,7 +26,7 @@ suite "Ring Buffer Channel Tests":
       result = values
     
     check fillBuffer(0) == @[0, 1, 2]
-    check fillBuffer(1) == @[3, 1, 2]
-    check fillBuffer(2) == @[3, 4, 2]
+    check fillBuffer(1) == @[1, 2, 3]
+    check fillBuffer(2) == @[2, 3, 4]
     check fillBuffer(3) == @[3, 4, 5]
-    check fillBuffer(4) == @[6, 4, 5]
+    check fillBuffer(4) == @[4, 5, 6]

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -31,8 +31,8 @@
 ## procs. Send operations add messages to the channel, receiving operations
 ## remove them.
 ##
-## Overwrite enables a ringbuffer mode where `send` overwrites the oldest message
-## if the channel is full.
+## Normally, the `send` proc will block if the channel is full. If the `overwrite`
+## parameter is set to `true`, the oldest message will be overwritten instead of blocking.
 ##
 ## See also:
 ## * [std/isolation](https://nim-lang.org/docs/isolation.html)

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -28,11 +28,10 @@
 ## the underlying resources and synchronization. It has to be initialized using
 ## the `newChan` proc. Sending and receiving operations are provided by the
 ## blocking `send` and `recv` procs, and non-blocking `trySend` and `tryRecv`
-## procs. Send operations add messages to the channel, receiving operations
-## remove them.
+## procs. For ring buffer behavior, use the `push` proc rather than `send`.
+## Send operations add messages to the channel, receiving operations remove them,
+## while `push` adds a message or overwrites the oldest message if the channel is full.
 ##
-## Normally, the `send` proc will block if the channel is full. If the `overwrite`
-## parameter is set to `true`, the oldest message will be overwritten instead of blocking.
 ##
 ## See also:
 ## * [std/isolation](https://nim-lang.org/docs/isolation.html)
@@ -102,8 +101,8 @@ runnableExamples("--threads:on --gc:orc"):
 
   block example_non_blocking_overwrite:
     var chanRingBuffer = newChan[string](elements = 1)
-    chanRingBuffer.send("Hello")
-    chanRingBuffer.send("World", overwrite = true)
+    chanRingBuffer.push("Hello")
+    chanRingBuffer.push("World")
     var msg = ""
     assert chanRingBuffer.tryRecv(msg)
     assert msg == "World"
@@ -367,7 +366,7 @@ proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## Returns `false` and does not change `dist` if no message was received.
   channelReceive(c.d, dst.addr, sizeof(T), false)
 
-proc send*[T](c: Chan[T], src: sink Isolated[T], overwrite = false) {.inline.} =
+proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
   ## Sends the message `src` to the channel `c`.
   ## This blocks the sending thread until `src` was successfully sent.
   ##
@@ -377,13 +376,31 @@ proc send*[T](c: Chan[T], src: sink Isolated[T], overwrite = false) {.inline.} =
   ## messages from the channel are removed.
   when defined(gcOrc) and defined(nimSafeOrcSend):
     GC_runOrc()
-  discard channelSend(c.d, src.addr, sizeof(T), true, overwrite)
+  discard channelSend(c.d, src.addr, sizeof(T), true, false)
   wasMoved(src)
 
-template send*[T](c: Chan[T]; src: T, overwrite = false) =
+template send*[T](c: Chan[T]; src: T) =
   ## Helper template for `send`.
   mixin isolate
-  send(c, isolate(src), overwrite)
+  send(c, isolate(src))
+
+proc push*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
+  ## Sends the message `src` to the channel `c`.
+  ## This blocks the sending thread until `src` was successfully sent.
+  ##
+  ## The memory of `src` is moved, not copied.
+  ##
+  ## If the channel is already full with messages this will block the thread until
+  ## messages from the channel are removed.
+  when defined(gcOrc) and defined(nimSafeOrcSend):
+    GC_runOrc()
+  discard channelSend(c.d, src.addr, sizeof(T), true, overwrite=true)
+  wasMoved(src)
+
+template push*[T](c: Chan[T]; src: T) =
+  ## Helper template for `push`.
+  mixin isolate
+  push(c, isolate(src))
 
 proc recv*[T](c: Chan[T], dst: var T) {.inline.} =
   ## Receives a message from the channel `c` and fill `dst` with its value.

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -322,7 +322,7 @@ proc trySend*[T](c: Chan[T], src: sink Isolated[T]): bool {.inline.} =
   ##
   ## Returns `false` if the message was not sent because the number of pending
   ## messages in the channel exceeded its capacity.
-  result = channelSend(c.d, src.addr, sizeof(T), false)
+  result = channelSend(c.d, src.addr, sizeof(T), false, false)
   if result:
     wasMoved(src)
 
@@ -350,7 +350,7 @@ proc tryTake*[T](c: Chan[T], src: var Isolated[T]): bool {.inline.} =
   ##
   ## Returns `false` if the message was not sent because the number of pending
   ## messages in the channel exceeded its capacity.
-  result = channelSend(c.d, src.addr, sizeof(T), false)
+  result = channelSend(c.d, src.addr, sizeof(T), false, false)
   if result:
     wasMoved(src)
 

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -222,7 +222,6 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
   if chan.getHead() == 2 * chan.slots:
     chan.setHead(0)
 
-  echo "send indexes prev: ", prevHead, " ", prevTail, " after: ", chan.getHead(), " ", chan.getTail(), " slots: ", chan.slots
   signal(chan.dataAvailableCV)
   release(chan.lock)
   result = true

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -181,6 +181,11 @@ proc freeChannel(chan: ChannelRaw) =
 # MPMC Channels (Multi-Producer Multi-Consumer)
 # ------------------------------------------------------------------------------
 
+template incrementReadIndex(chan: ChannelRaw) =
+  atomicInc(chan.tail)
+  if chan.getTail() == 2 * chan.slots:
+    chan.setTail(0)
+
 proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
   assert not chan.isNil
   assert not data.isNil
@@ -195,13 +200,19 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
     while chan.isFull():
       wait(chan.spaceAvailableCV, chan.lock)
   else:
-    if chan.isFull() and not chan.overwrite:
-      release(chan.lock)
-      return false
+    if chan.isFull():
+      if chan.overwrite:
+        incrementReadIndex(chan)
+      else:
+        release(chan.lock)
+        return false
 
+  let prevHead = chan.getHead()
+  let prevTail = chan.getTail()
   assert not chan.isFull() or chan.overwrite
 
-  let writeIdx = if chan.getHead() < chan.slots:
+  let writeIdx =
+    if chan.getHead() < chan.slots:
       chan.getHead()
     else:
       chan.getHead() - chan.slots
@@ -211,6 +222,7 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
   if chan.getHead() == 2 * chan.slots:
     chan.setHead(0)
 
+  echo "send indexes prev: ", prevHead, " ", prevTail, " after: ", chan.getHead(), " ", chan.getTail(), " slots: ", chan.slots
   signal(chan.dataAvailableCV)
   release(chan.lock)
   result = true
@@ -235,16 +247,15 @@ proc channelReceive(chan: ChannelRaw, data: pointer, size: int, blocking: static
 
   assert not chan.isEmpty()
 
-  let readIdx = if chan.getTail() < chan.slots:
+  let readIdx =
+    if chan.getTail() < chan.slots:
       chan.getTail()
     else:
       chan.getTail() - chan.slots
 
   copyMem(data, chan.buffer[readIdx * size].addr, size)
 
-  atomicInc(chan.tail)
-  if chan.getTail() == 2 * chan.slots:
-    chan.setTail(0)
+  incrementReadIndex(chan)
 
   signal(chan.spaceAvailableCV)
   release(chan.lock)

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -31,6 +31,9 @@
 ## procs. Send operations add messages to the channel, receiving operations
 ## remove them.
 ##
+## Overwrite enables a ringbuffer mode where `send` overwrites the oldest message
+## if the channel is full.
+##
 ## See also:
 ## * [std/isolation](https://nim-lang.org/docs/isolation.html)
 ##
@@ -96,6 +99,14 @@ runnableExamples("--threads:on --gc:orc"):
     assert messages[^1] == "Another message"
     # At least one non-successful attempt to receive the message had to occur.
     assert messages.len >= 2
+
+  block example_non_blocking_overwrite:
+    var chan = newChan[string](elements = 1, overwrite = true)
+    discard chan.send("Hello")
+    discard chan.send("World")
+    var msg = ""
+    assert chan.tryRecv(msg)
+    assert msg == "World"
 
 when not (defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc) or defined(nimdoc)):
   {.error: "This module requires one of --mm:arc / --mm:atomicArc / --mm:orc compilation flags".}
@@ -197,19 +208,18 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
 
   # check for when another thread was faster to fill
   when blocking:
-    while chan.isFull():
-      wait(chan.spaceAvailableCV, chan.lock)
-  else:
     if chan.isFull():
       if chan.overwrite:
         incrementReadIndex(chan)
       else:
-        release(chan.lock)
-        return false
+        while chan.isFull():
+          wait(chan.spaceAvailableCV, chan.lock)
+  else:
+    if chan.isFull():
+      release(chan.lock)
+      return false
 
-  let prevHead = chan.getHead()
-  let prevTail = chan.getTail()
-  assert not chan.isFull() or chan.overwrite
+  assert not chan.isFull()
 
   let writeIdx =
     if chan.getHead() < chan.slots:

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -385,13 +385,10 @@ template send*[T](c: Chan[T]; src: T) =
   send(c, isolate(src))
 
 proc push*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
-  ## Sends the message `src` to the channel `c`.
-  ## This blocks the sending thread until `src` was successfully sent.
+  ## Pushes the message `src` to the channel `c`.
+  ## This is a non-blocking operation that overwrites the oldest message if the channel is full.
   ##
   ## The memory of `src` is moved, not copied.
-  ##
-  ## If the channel is already full with messages this will block the thread until
-  ## messages from the channel are removed.
   when defined(gcOrc) and defined(nimSafeOrcSend):
     GC_runOrc()
   discard channelSend(c.d, src.addr, sizeof(T), true, overwrite=true)

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -110,11 +110,12 @@ type
   ChannelObj = object
     lock: Lock
     spaceAvailableCV, dataAvailableCV: Cond
+    overwrite: bool
     slots: int         ## Number of item slots in the buffer
     head: Atomic[int]  ## Write/enqueue/send index
     tail: Atomic[int]  ## Read/dequeue/receive index
-    buffer: ptr UncheckedArray[byte]
     atomicCounter: Atomic[int]
+    buffer: ptr UncheckedArray[byte]
 
 # ------------------------------------------------------------------------------
 
@@ -185,7 +186,7 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
   assert not data.isNil
 
   when not blocking:
-    if chan.isFull(): return false
+    if chan.isFull() and not chan.overwrite: return false
 
   acquire(chan.lock)
 
@@ -194,11 +195,11 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
     while chan.isFull():
       wait(chan.spaceAvailableCV, chan.lock)
   else:
-    if chan.isFull():
+    if chan.isFull() and not chan.overwrite:
       release(chan.lock)
       return false
 
-  assert not chan.isFull()
+  assert not chan.isFull() or chan.overwrite
 
   let writeIdx = if chan.getHead() < chan.slots:
       chan.getHead()
@@ -384,10 +385,11 @@ proc peek*[T](c: Chan[T]): int {.inline.} =
   ## Returns an estimation of the current number of messages held by the channel.
   numItems(c.d)
 
-proc newChan*[T](elements: Positive = 30): Chan[T] =
+proc newChan*[T](elements: Positive = 30, overwrite = false): Chan[T] =
   ## An initialization procedure, necessary for acquiring resources and
   ## initializing internal state of the channel.
   ##
   ## `elements` is the capacity of the channel and thus how many messages it can hold
   ## before it refuses to accept any further messages.
   result = Chan[T](d: allocChannel(sizeof(T), elements))
+  result.d.overwrite = overwrite

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -101,11 +101,11 @@ runnableExamples("--threads:on --gc:orc"):
     assert messages.len >= 2
 
   block example_non_blocking_overwrite:
-    var chan = newChan[string](elements = 1, overwrite = true)
-    discard chan.send("Hello")
-    discard chan.send("World")
+    var chanRingBuffer = newChan[string](elements = 1, overwrite = true)
+    chanRingBuffer.send("Hello")
+    chanRingBuffer.send("World")
     var msg = ""
-    assert chan.tryRecv(msg)
+    assert chanRingBuffer.tryRecv(msg)
     assert msg == "World"
 
 when not (defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc) or defined(nimdoc)):

--- a/threading/channels.nim
+++ b/threading/channels.nim
@@ -101,9 +101,9 @@ runnableExamples("--threads:on --gc:orc"):
     assert messages.len >= 2
 
   block example_non_blocking_overwrite:
-    var chanRingBuffer = newChan[string](elements = 1, overwrite = true)
+    var chanRingBuffer = newChan[string](elements = 1)
     chanRingBuffer.send("Hello")
-    chanRingBuffer.send("World")
+    chanRingBuffer.send("World", overwrite = true)
     var msg = ""
     assert chanRingBuffer.tryRecv(msg)
     assert msg == "World"
@@ -121,7 +121,6 @@ type
   ChannelObj = object
     lock: Lock
     spaceAvailableCV, dataAvailableCV: Cond
-    overwrite: bool
     slots: int         ## Number of item slots in the buffer
     head: Atomic[int]  ## Write/enqueue/send index
     tail: Atomic[int]  ## Read/dequeue/receive index
@@ -192,25 +191,30 @@ proc freeChannel(chan: ChannelRaw) =
 # MPMC Channels (Multi-Producer Multi-Consumer)
 # ------------------------------------------------------------------------------
 
-template incrementReadIndex(chan: ChannelRaw) =
+template incrWriteIndex(chan: ChannelRaw) =
+  atomicInc(chan.head)
+  if chan.getHead() == 2 * chan.slots:
+    chan.setHead(0)
+
+template incrReadIndex(chan: ChannelRaw) =
   atomicInc(chan.tail)
   if chan.getTail() == 2 * chan.slots:
     chan.setTail(0)
 
-proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bool): bool =
+proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bool, overwrite: bool): bool =
   assert not chan.isNil
   assert not data.isNil
 
   when not blocking:
-    if chan.isFull() and not chan.overwrite: return false
+    if chan.isFull() and not overwrite: return false
 
   acquire(chan.lock)
 
   # check for when another thread was faster to fill
   when blocking:
     if chan.isFull():
-      if chan.overwrite:
-        incrementReadIndex(chan)
+      if overwrite:
+        incrReadIndex(chan)
       else:
         while chan.isFull():
           wait(chan.spaceAvailableCV, chan.lock)
@@ -228,9 +232,8 @@ proc channelSend(chan: ChannelRaw, data: pointer, size: int, blocking: static bo
       chan.getHead() - chan.slots
 
   copyMem(chan.buffer[writeIdx * size].addr, data, size)
-  atomicInc(chan.head)
-  if chan.getHead() == 2 * chan.slots:
-    chan.setHead(0)
+
+  incrWriteIndex(chan)
 
   signal(chan.dataAvailableCV)
   release(chan.lock)
@@ -264,7 +267,7 @@ proc channelReceive(chan: ChannelRaw, data: pointer, size: int, blocking: static
 
   copyMem(data, chan.buffer[readIdx * size].addr, size)
 
-  incrementReadIndex(chan)
+  incrReadIndex(chan)
 
   signal(chan.spaceAvailableCV)
   release(chan.lock)
@@ -364,7 +367,7 @@ proc tryRecv*[T](c: Chan[T], dst: var T): bool {.inline.} =
   ## Returns `false` and does not change `dist` if no message was received.
   channelReceive(c.d, dst.addr, sizeof(T), false)
 
-proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
+proc send*[T](c: Chan[T], src: sink Isolated[T], overwrite = false) {.inline.} =
   ## Sends the message `src` to the channel `c`.
   ## This blocks the sending thread until `src` was successfully sent.
   ##
@@ -374,13 +377,13 @@ proc send*[T](c: Chan[T], src: sink Isolated[T]) {.inline.} =
   ## messages from the channel are removed.
   when defined(gcOrc) and defined(nimSafeOrcSend):
     GC_runOrc()
-  discard channelSend(c.d, src.addr, sizeof(T), true)
+  discard channelSend(c.d, src.addr, sizeof(T), true, overwrite)
   wasMoved(src)
 
-template send*[T](c: Chan[T]; src: T) =
+template send*[T](c: Chan[T]; src: T, overwrite = false) =
   ## Helper template for `send`.
   mixin isolate
-  send(c, isolate(src))
+  send(c, isolate(src), overwrite)
 
 proc recv*[T](c: Chan[T], dst: var T) {.inline.} =
   ## Receives a message from the channel `c` and fill `dst` with its value.
@@ -405,11 +408,10 @@ proc peek*[T](c: Chan[T]): int {.inline.} =
   ## Returns an estimation of the current number of messages held by the channel.
   numItems(c.d)
 
-proc newChan*[T](elements: Positive = 30, overwrite = false): Chan[T] =
+proc newChan*[T](elements: Positive = 30): Chan[T] =
   ## An initialization procedure, necessary for acquiring resources and
   ## initializing internal state of the channel.
   ##
   ## `elements` is the capacity of the channel and thus how many messages it can hold
   ## before it refuses to accept any further messages.
   result = Chan[T](d: allocChannel(sizeof(T), elements))
-  result.d.overwrite = overwrite


### PR DESCRIPTION
In some cases it's useful to have a channel which acts as a ring-buffer that overwrites the oldest data.

For example in UIs you often want the last mouse input. The alternatives like calling `tryRecv` and then `send` require taking the lock multiple times and adds odd edge-cases.

Alternatively this could be made into a new proc `sendOverwrite` or `forceSend` as `send(ch, val, overwrite=true)` is no longer blocking in a sense.